### PR TITLE
feat: adding clingy ci and also cmake test

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,60 @@
+---
+# Configuration for clang-tidy linter
+Checks: >
+  -*,
+  bugprone-*,
+  cert-*,
+  clang-analyzer-*,
+  concurrency-*,
+  cppcoreguidelines-*,
+  misc-*,
+  modernize-*,
+  performance-*,
+  portability-*,
+  readability-*,
+  -modernize-use-trailing-return-type,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -readability-magic-numbers,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -readability-identifier-length,
+  -modernize-use-nodiscard
+
+WarningsAsErrors: ''
+HeaderFilterRegex: '.*'
+FormatStyle: 'file'
+
+CheckOptions:
+  - key: readability-identifier-naming.NamespaceCase
+    value: lower_case
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.StructCase
+    value: CamelCase
+  - key: readability-identifier-naming.TemplateParameterCase
+    value: CamelCase
+  - key: readability-identifier-naming.FunctionCase
+    value: camelBack
+  - key: readability-identifier-naming.VariableCase
+    value: camelBack
+  - key: readability-identifier-naming.PrivateMemberSuffix
+    value: '_'
+  - key: readability-identifier-naming.ProtectedMemberSuffix
+    value: '_'
+  - key: readability-identifier-naming.MacroDefinitionCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.EnumConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.ConstexprVariableCase
+    value: UPPER_CASE
+  - key: readability-function-cognitive-complexity.Threshold
+    value: 25
+  - key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+    value: true
+  - key: modernize-loop-convert.MaxCopySize
+    value: 16
+  - key: modernize-loop-convert.MinConfidence
+    value: reasonable
+  - key: modernize-use-auto.MinTypeNameLength
+    value: 5

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
 
 jobs:
   build:
@@ -23,3 +23,35 @@ jobs:
 
       - name: Build
         run: cmake --build build --config Release
+
+  lint:
+    name: Code Linting with clang-tidy
+    runs-on: ubuntu-latest
+    continue-on-error: true  # none blocking
+    if: github.base_ref == 'main'
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install clang-tidy
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-tidy
+
+      - name: Configure CMake with clang-tidy
+        run: cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+      - name: Run clang-tidy
+        run: |
+          echo "Running clang-tidy analysis..."
+          run-clang-tidy -p build -j $(nproc) 2>&1 | tee clang-tidy-report.txt || true
+          echo "Clang-tidy analysis completed (non-blocking)"
+
+      - name: Upload clang-tidy report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: clang-tidy-report
+          path: clang-tidy-report.txt
+          retention-days: 30

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,18 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# clang-tidy integration
+option(ENABLE_CLANG_TIDY "Enable clang-tidy analysis during build" OFF)
+if(ENABLE_CLANG_TIDY)
+    find_program(CLANG_TIDY_EXE NAMES "clang-tidy")
+    if(CLANG_TIDY_EXE)
+        message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
+        set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
+    else()
+        message(WARNING "clang-tidy not found!")
+    endif()
+endif()
+
 option(BUILD_CLIENT "Build client executable" ON)
 option(BUILD_SERVER "Build server executable" ON)
 


### PR DESCRIPTION
This pull request introduces clang-tidy static analysis into the project, improving code quality and maintainability. It adds a clang-tidy configuration file, integrates optional clang-tidy checks into the CMake build system, and updates the CI workflow to run linting on pull requests targeting the `main` branch. These changes ensure consistent linting standards and provide automated feedback on code style and potential issues.

**Clang-tidy integration and configuration:**

* Added a `.clang-tidy` configuration file specifying enabled checks, naming conventions, and custom options for code analysis.
* Updated `CMakeLists.txt` to support optional clang-tidy analysis during builds via the `ENABLE_CLANG_TIDY` option, including detection of the `clang-tidy` executable.

**CI workflow enhancements:**

* Modified the CI workflow to run on both `main` and `dev` branches for pull requests, increasing coverage.
* Added a non-blocking lint job to the CI workflow that runs clang-tidy analysis and uploads its report as an artifact, only for PRs targeting the `main` branch.