### PR TITLE
feat(core): add EventBus pub/sub system for ECS decoupling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build/
+.vscode
+docs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 option(BUILD_CLIENT "Build client executable" ON)
 option(BUILD_SERVER "Build server executable" ON)
+option(BUILD_TESTS "Build unit tests" ON)
 
 # list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 # include(CPM)
@@ -21,4 +22,8 @@ endif()
 
 if (BUILD_CLIENT)
     add_subdirectory(client)
+endif()
+
+if (BUILD_TESTS)
+    add_subdirectory(tests)
 endif()

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 add_library(rtype_engine
     src/Test.cpp
+    src/core/event/EventBus.cpp
 )
 
 target_include_directories(rtype_engine

--- a/engine/include/core/event/Event.hpp
+++ b/engine/include/core/event/Event.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace core {
+
+/**
+ * @brief Base interface for all events in the ECS architecture
+ *
+ * All event types should inherit from this interface to be used
+ * with the EventBus system. This ensures type safety while allowing
+ * runtime polymorphism when needed.
+ *
+ * Events should be lightweight data structures containing only
+ * the information needed to communicate between systems.
+ */
+struct Event {
+    virtual ~Event() = default;
+};
+
+}

--- a/engine/include/core/event/EventBus.hpp
+++ b/engine/include/core/event/EventBus.hpp
@@ -1,0 +1,110 @@
+#pragma once
+
+#include "Event.hpp"
+#include <functional>
+#include <memory>
+#include <queue>
+#include <typeindex>
+#include <unordered_map>
+#include <vector>
+#include <any>
+
+namespace core {
+
+/**
+ * @brief Generic event bus implementation using publish/subscribe pattern
+ *
+ * The EventBus provides a decoupled communication mechanism between systems.
+ * Systems can publish events without knowing who consumes them, and subscribe
+ * to events they're interested in without knowing the publisher.
+ */
+class EventBus {
+    public:
+        using SubscriptionId = size_t;
+
+        EventBus();
+        ~EventBus() = default;
+
+        /**
+         * @brief Subscribe to an event type with a callback function
+         */
+        template<typename EventType>
+        SubscriptionId subscribe(std::function<void(const EventType&)> callback);
+
+        /**
+         * @brief Publish an event immediately to all subscribers
+         */
+        template<typename EventType>
+        void publish(const EventType& event);
+
+        /**
+         * @brief Queue an event for deferred processing
+         */
+        template<typename EventType>
+        void publish_deferred(const EventType& event);
+
+        /**
+         * @brief Process all deferred events in the queue
+         */
+        void process_deferred();
+
+        /**
+         * @brief Unsubscribe from events using a subscription ID
+         */
+        void unsubscribe(SubscriptionId subscriptionId);
+
+        /**
+         * @brief Clear all subscribers and pending events
+         */
+        void clear();
+
+        /**
+         * @brief Get the number of subscribers for a specific event type
+         */
+        template<typename EventType>
+        size_t getSubscriberCount() const;
+
+        /**
+         * @brief Get the number of deferred events waiting to be processed
+         */
+        size_t getDeferredEventCount() const;
+
+    private:
+        using Callback = std::function<void(const std::any&)>;
+        using Subscription = std::pair<SubscriptionId, Callback>;
+        using DeferredPublisher = std::function<void()>;
+
+        SubscriptionId subscribeImpl(std::type_index typeIndex, Callback callback);
+        void publishImpl(std::type_index typeIndex, const std::any& event);
+        void publishDeferredImpl(std::type_index typeIndex, const std::any& event);
+        size_t getSubscriberCountImpl(std::type_index typeIndex) const;
+
+        std::unordered_map<std::type_index, std::vector<Subscription>> subscribers_;
+        std::queue<DeferredPublisher> deferredEvents_;
+        SubscriptionId nextSubscriptionId_;
+    };
+
+    template<typename EventType>
+    EventBus::SubscriptionId EventBus::subscribe(std::function<void(const EventType&)> callback) {
+        auto wrapper = [callback](const std::any& event) {
+            callback(std::any_cast<const EventType&>(event));
+        };
+        return subscribeImpl(typeid(EventType), wrapper);
+    }
+
+    template<typename EventType>
+    void EventBus::publish(const EventType& event) {
+        publishImpl(typeid(EventType), event);
+    }
+
+    template<typename EventType>
+    void EventBus::publish_deferred(const EventType& event) {
+        publishDeferredImpl(typeid(EventType), event);
+    }
+
+    template<typename EventType>
+    size_t EventBus::getSubscriberCount() const {
+        return getSubscriberCountImpl(typeid(EventType));
+    }
+
+}

--- a/engine/src/core/event/EventBus.cpp
+++ b/engine/src/core/event/EventBus.cpp
@@ -1,0 +1,145 @@
+#include "core/event/EventBus.hpp"
+#include <algorithm>
+
+namespace core {
+
+/**
+ * @brief Constructor initializing the subscription ID counter
+ */
+EventBus::EventBus() : nextSubscriptionId_(0) {}
+
+/**
+ * @brief Internal implementation of subscription logic
+ *
+ * Adds a callback to the subscribers map for the given event type.
+ * Each subscription is assigned a unique ID for later unsubscription.
+ *
+ * @param typeIndex The type_index of the event type
+ * @param callback The callback function wrapped in type erasure
+ * @return Unique subscription ID
+ */
+EventBus::SubscriptionId EventBus::subscribeImpl(std::type_index typeIndex, Callback callback) {
+    SubscriptionId id = nextSubscriptionId_++;
+
+    subscribers_[typeIndex].push_back({id, callback});
+    return id;
+}
+
+/**
+ * @brief Internal implementation of immediate event publishing
+ *
+ * Finds all subscribers for the given event type and invokes their
+ * callbacks synchronously in the order they subscribed.
+ *
+ * @param typeIndex The type_index of the event type
+ * @param event The event data wrapped in std::any
+ */
+void EventBus::publishImpl(std::type_index typeIndex, const std::any& event) {
+    auto it = subscribers_.find(typeIndex);
+    if (it != subscribers_.end())
+        for (auto& [id, callback] : it->second)
+            callback(event);
+}
+
+/**
+ * @brief Internal implementation of deferred event publishing
+ *
+ * Creates a lambda that captures the event and type information,
+ * then queues it for later execution during process_deferred().
+ *
+ * The event data is copied into the lambda to ensure it remains
+ * valid when the deferred event is processed.
+ *
+ * @param typeIndex The type_index of the event type
+ * @param event The event data wrapped in std::any
+ */
+void EventBus::publishDeferredImpl(std::type_index typeIndex, const std::any& event) {
+    auto publisher = [this, typeIndex, event]() {
+        auto it = subscribers_.find(typeIndex);
+        if (it != subscribers_.end())
+            for (auto& [id, callback] : it->second)
+                callback(event);
+    };
+    deferredEvents_.push(publisher);
+}
+
+/**
+ * @brief Process all deferred events in the queue
+ *
+ * This method should typically be called once per frame, at a point where
+ * it's safe to handle all pending events (e.g., end of update loop).
+ *
+ * Events are processed in FIFO order (first queued, first processed).
+ * The queue is cleared after processing all events.
+ */
+void EventBus::process_deferred() {
+    while (!deferredEvents_.empty()) {
+        auto& publisher = deferredEvents_.front();
+        publisher();
+        deferredEvents_.pop();
+    }
+}
+
+/**
+ * @brief Unsubscribe from events using a subscription ID
+ *
+ * Iterates through all event types and removes any subscription
+ * matching the given ID. If the ID is not found, this method
+ * does nothing (no error is thrown).
+ *
+ * Uses the erase-remove idiom for efficient removal from vectors.
+ *
+ * @param subscriptionId The ID returned by subscribe()
+ */
+void EventBus::unsubscribe(SubscriptionId subscriptionId) {
+    for (auto& [typeIndex, subs] : subscribers_) {
+        auto it = std::remove_if(subs.begin(), subs.end(),
+            [subscriptionId](const auto& sub) {return sub.first == subscriptionId;});
+        subs.erase(it, subs.end());
+    }
+}
+
+/**
+ * @brief Clear all subscribers and pending events
+ *
+ * This is primarily useful for testing or when resetting the game state.
+ * After calling this, the EventBus will be in a clean state with:
+ * - No subscribers for any event type
+ * - No pending deferred events in the queue
+ * - Subscription ID counter reset to 0
+ */
+void EventBus::clear() {
+    subscribers_.clear();
+    while (!deferredEvents_.empty())
+        deferredEvents_.pop();
+    nextSubscriptionId_ = 0;
+}
+
+/**
+ * @brief Internal implementation to get subscriber count
+ *
+ * Looks up the subscriber list for the given event type and
+ * returns the number of active subscribers.
+ *
+ * @param typeIndex The type_index of the event type
+ * @return Number of active subscribers, or 0 if none
+ */
+size_t EventBus::getSubscriberCountImpl(std::type_index typeIndex) const {
+    auto it = subscribers_.find(typeIndex);
+
+    return (it != subscribers_.end()) ? it->second.size() : 0;
+}
+
+/**
+ * @brief Get the number of deferred events waiting to be processed
+ *
+ * This can be useful for debugging or monitoring purposes to see
+ * how many events are queued and waiting for process_deferred().
+ *
+ * @return Number of events in the deferred queue
+ */
+size_t EventBus::getDeferredEventCount() const {
+    return deferredEvents_.size();
+}
+
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.20)
+
+# Enable testing
+enable_testing()
+
+# Find Google Test
+find_package(GTest REQUIRED)
+include_directories(${GTEST_INCLUDE_DIRS})
+
+# Include engine headers
+include_directories(${CMAKE_SOURCE_DIR}/engine/include)
+
+# EventBus tests
+add_executable(test_eventbus
+    core/event/test_eventbus.cpp
+)
+
+target_link_libraries(test_eventbus
+    rtype_engine
+    ${GTEST_LIBRARIES}
+    ${GTEST_MAIN_LIBRARIES}
+    pthread
+)
+
+# Add test to CTest
+add_test(NAME EventBusTests COMMAND test_eventbus)
+
+# Set C++ standard
+set_property(TARGET test_eventbus PROPERTY CXX_STANDARD 20)

--- a/tests/core/event/test_eventbus.cpp
+++ b/tests/core/event/test_eventbus.cpp
@@ -1,0 +1,354 @@
+#include "core/event/EventBus.hpp"
+#include "core/event/Event.hpp"
+#include <gtest/gtest.h>
+#include <string>
+
+struct TestEvent : public core::Event {
+    int value;
+    explicit TestEvent(int v) : value(v) {}
+};
+
+struct AnotherTestEvent : public core::Event {
+    std::string message;
+    explicit AnotherTestEvent(const std::string& msg) : message(msg) {}
+};
+
+struct ComplexEvent : public core::Event {
+    int id;
+    float x, y;
+    ComplexEvent(int i, float px, float py) : id(i), x(px), y(py) {}
+};
+
+TEST(EventBusTest, SubscribeAndPublishImmediate) {
+    core::EventBus bus;
+    int callCount = 0;
+    int receivedValue = 0;
+
+    bus.subscribe<TestEvent>([&](const TestEvent& evt) {
+        callCount++;
+        receivedValue = evt.value;
+    });
+    bus.publish(TestEvent{42});
+    EXPECT_EQ(callCount, 1);
+    EXPECT_EQ(receivedValue, 42);
+}
+
+TEST(EventBusTest, MultipleSubscribersReceiveEvent) {
+    core::EventBus bus;
+    int callCount1 = 0, callCount2 = 0, callCount3 = 0;
+    int value1 = 0, value2 = 0, value3 = 0;
+
+    bus.subscribe<TestEvent>([&](const TestEvent& evt) {
+        callCount1++;
+        value1 = evt.value;
+    });
+    bus.subscribe<TestEvent>([&](const TestEvent& evt) {
+        callCount2++;
+        value2 = evt.value;
+    });
+    bus.subscribe<TestEvent>([&](const TestEvent& evt) {
+        callCount3++;
+        value3 = evt.value;
+    });
+    bus.publish(TestEvent{100});
+    EXPECT_EQ(callCount1, 1);
+    EXPECT_EQ(callCount2, 1);
+    EXPECT_EQ(callCount3, 1);
+    EXPECT_EQ(value1, 100);
+    EXPECT_EQ(value2, 100);
+    EXPECT_EQ(value3, 100);
+}
+
+TEST(EventBusTest, DifferentEventTypesAreIndependent) {
+    core::EventBus bus;
+    int testEventCount = 0;
+    int anotherEventCount = 0;
+
+    bus.subscribe<TestEvent>([&](const TestEvent&) {
+        testEventCount++;
+    });
+    bus.subscribe<AnotherTestEvent>([&](const AnotherTestEvent&) {
+        anotherEventCount++;
+    });
+    bus.publish(TestEvent{1});
+    EXPECT_EQ(testEventCount, 1);
+    EXPECT_EQ(anotherEventCount, 0);
+    bus.publish(AnotherTestEvent{"hello"});
+    EXPECT_EQ(testEventCount, 1);
+    EXPECT_EQ(anotherEventCount, 1);
+    bus.publish(TestEvent{2});
+    EXPECT_EQ(testEventCount, 2);
+    EXPECT_EQ(anotherEventCount, 1);
+}
+
+TEST(EventBusTest, PublishWithoutSubscribersDoesNotCrash) {
+    core::EventBus bus;
+    EXPECT_NO_THROW(bus.publish(TestEvent{123}));
+}
+
+TEST(EventBusTest, DeferredEventIsNotProcessedImmediately) {
+    core::EventBus bus;
+    int callCount = 0;
+
+    bus.subscribe<TestEvent>([&](const TestEvent&) {
+        callCount++;
+    });
+    bus.publish_deferred(TestEvent{42});
+    EXPECT_EQ(callCount, 0);
+}
+
+TEST(EventBusTest, ProcessDeferredCallsSubscribers) {
+    core::EventBus bus;
+    int callCount = 0;
+    int receivedValue = 0;
+
+    bus.subscribe<TestEvent>([&](const TestEvent& evt) {
+        callCount++;
+        receivedValue = evt.value;
+    });
+    bus.publish_deferred(TestEvent{42});
+    bus.process_deferred();
+    EXPECT_EQ(callCount, 1);
+    EXPECT_EQ(receivedValue, 42);
+}
+
+TEST(EventBusTest, MultipleDeferredEventsProcessedInOrder) {
+    core::EventBus bus;
+    std::vector<int> receivedValues;
+
+    bus.subscribe<TestEvent>([&](const TestEvent& evt) {
+        receivedValues.push_back(evt.value);
+    });
+    bus.publish_deferred(TestEvent{1});
+    bus.publish_deferred(TestEvent{2});
+    bus.publish_deferred(TestEvent{3});
+    EXPECT_EQ(receivedValues.size(), 0);
+    bus.process_deferred();
+    ASSERT_EQ(receivedValues.size(), 3);
+    EXPECT_EQ(receivedValues[0], 1);
+    EXPECT_EQ(receivedValues[1], 2);
+    EXPECT_EQ(receivedValues[2], 3);
+}
+
+TEST(EventBusTest, MixedImmediateAndDeferredEvents) {
+    core::EventBus bus;
+    std::vector<int> receivedValues;
+
+    bus.subscribe<TestEvent>([&](const TestEvent& evt) {
+        receivedValues.push_back(evt.value);
+    });
+
+    bus.publish(TestEvent{1});           // Immediate
+    bus.publish_deferred(TestEvent{2});  // Deferred
+    bus.publish(TestEvent{3});           // Immediate
+    bus.publish_deferred(TestEvent{4});  // Deferred
+
+    ASSERT_EQ(receivedValues.size(), 2);
+    EXPECT_EQ(receivedValues[0], 1);
+    EXPECT_EQ(receivedValues[1], 3);
+
+    bus.process_deferred();
+
+    ASSERT_EQ(receivedValues.size(), 4);
+    EXPECT_EQ(receivedValues[2], 2);
+    EXPECT_EQ(receivedValues[3], 4);
+}
+
+TEST(EventBusTest, ProcessDeferredMultipleTimes) {
+    core::EventBus bus;
+    int callCount = 0;
+
+    bus.subscribe<TestEvent>([&](const TestEvent&) {
+        callCount++;
+    });
+    bus.publish_deferred(TestEvent{1});
+    bus.process_deferred();
+    EXPECT_EQ(callCount, 1);
+    bus.publish_deferred(TestEvent{2});
+    bus.publish_deferred(TestEvent{3});
+    bus.process_deferred();
+    EXPECT_EQ(callCount, 3);
+    bus.process_deferred();
+    EXPECT_EQ(callCount, 3);
+}
+
+TEST(EventBusTest, UnsubscribeRemovesSubscriber) {
+    core::EventBus bus;
+    int callCount = 0;
+    auto id = bus.subscribe<TestEvent>([&](const TestEvent&) {
+        callCount++;
+    });
+
+    bus.publish(TestEvent{1});
+    EXPECT_EQ(callCount, 1);
+    bus.unsubscribe(id);
+    bus.publish(TestEvent{2});
+    EXPECT_EQ(callCount, 1);
+}
+
+TEST(EventBusTest, UnsubscribeOneOfMultipleSubscribers) {
+    core::EventBus bus;
+    int callCount1 = 0, callCount2 = 0;
+
+    auto id1 = bus.subscribe<TestEvent>([&](const TestEvent&) {
+        callCount1++;
+    });
+    bus.subscribe<TestEvent>([&](const TestEvent&) {
+        callCount2++;
+    });
+    bus.publish(TestEvent{1});
+    EXPECT_EQ(callCount1, 1);
+    EXPECT_EQ(callCount2, 1);
+    bus.unsubscribe(id1);
+    bus.publish(TestEvent{2});
+    EXPECT_EQ(callCount1, 1);
+    EXPECT_EQ(callCount2, 2);
+}
+
+TEST(EventBusTest, UnsubscribeNonExistentIdDoesNotCrash) {
+    core::EventBus bus;
+    EXPECT_NO_THROW(bus.unsubscribe(999999));
+}
+
+TEST(EventBusTest, GetSubscriberCount) {
+    core::EventBus bus;
+
+    EXPECT_EQ(bus.getSubscriberCount<TestEvent>(), 0);
+    auto id1 = bus.subscribe<TestEvent>([](const TestEvent&) {});
+    EXPECT_EQ(bus.getSubscriberCount<TestEvent>(), 1);
+    auto id2 = bus.subscribe<TestEvent>([](const TestEvent&) {});
+    EXPECT_EQ(bus.getSubscriberCount<TestEvent>(), 2);
+    bus.subscribe<AnotherTestEvent>([](const AnotherTestEvent&) {});
+    EXPECT_EQ(bus.getSubscriberCount<TestEvent>(), 2);
+    EXPECT_EQ(bus.getSubscriberCount<AnotherTestEvent>(), 1);
+    bus.unsubscribe(id1);
+    EXPECT_EQ(bus.getSubscriberCount<TestEvent>(), 1);
+    bus.unsubscribe(id2);
+    EXPECT_EQ(bus.getSubscriberCount<TestEvent>(), 0);
+}
+
+TEST(EventBusTest, ClearRemovesAllSubscribers) {
+    core::EventBus bus;
+    int callCount = 0;
+
+    bus.subscribe<TestEvent>([&](const TestEvent&) {
+        callCount++;
+    });
+    bus.subscribe<AnotherTestEvent>([&](const AnotherTestEvent&) {
+        callCount++;
+    });
+    bus.clear();
+    bus.publish(TestEvent{1});
+    bus.publish(AnotherTestEvent{"test"});
+    EXPECT_EQ(callCount, 0);
+    EXPECT_EQ(bus.getSubscriberCount<TestEvent>(), 0);
+    EXPECT_EQ(bus.getSubscriberCount<AnotherTestEvent>(), 0);
+}
+
+TEST(EventBusTest, ClearRemovesDeferredEvents) {
+    core::EventBus bus;
+    int callCount = 0;
+
+    bus.subscribe<TestEvent>([&](const TestEvent&) {
+        callCount++;
+    });
+    bus.publish_deferred(TestEvent{1});
+    bus.publish_deferred(TestEvent{2});
+    EXPECT_EQ(bus.getDeferredEventCount(), 2);
+    bus.clear();
+    EXPECT_EQ(bus.getDeferredEventCount(), 0);
+    bus.process_deferred();
+    EXPECT_EQ(callCount, 0);
+}
+
+TEST(EventBusTest, ComplexEventData) {
+    core::EventBus bus;
+    int receivedId = 0;
+    float receivedX = 0.0f, receivedY = 0.0f;
+
+    bus.subscribe<ComplexEvent>([&](const ComplexEvent& evt) {
+        receivedId = evt.id;
+        receivedX = evt.x;
+        receivedY = evt.y;
+    });
+    bus.publish(ComplexEvent{42, 3.14f, 2.71f});
+    EXPECT_EQ(receivedId, 42);
+    EXPECT_FLOAT_EQ(receivedX, 3.14f);
+    EXPECT_FLOAT_EQ(receivedY, 2.71f);
+}
+
+TEST(EventBusTest, StringEventData) {
+    core::EventBus bus;
+    std::string receivedMessage;
+
+    bus.subscribe<AnotherTestEvent>([&](const AnotherTestEvent& evt) {
+        receivedMessage = evt.message;
+    });
+    bus.publish(AnotherTestEvent{"Hello, EventBus!"});
+    EXPECT_EQ(receivedMessage, "Hello, EventBus!");
+}
+
+TEST(EventBusTest, GetDeferredEventCount) {
+    core::EventBus bus;
+
+    EXPECT_EQ(bus.getDeferredEventCount(), 0);
+    bus.publish_deferred(TestEvent{1});
+    EXPECT_EQ(bus.getDeferredEventCount(), 1);
+    bus.publish_deferred(TestEvent{2});
+    bus.publish_deferred(TestEvent{3});
+    EXPECT_EQ(bus.getDeferredEventCount(), 3);
+    bus.process_deferred();
+    EXPECT_EQ(bus.getDeferredEventCount(), 0);
+}
+
+TEST(EventBusTest, SubscribeAfterPublishDeferred) {
+    core::EventBus bus;
+    int callCount = 0;
+
+    bus.publish_deferred(TestEvent{1});
+    bus.subscribe<TestEvent>([&](const TestEvent&) {
+        callCount++;
+    });
+    bus.process_deferred();
+    EXPECT_EQ(callCount, 1);
+}
+
+TEST(EventBusTest, MultipleProcessDeferredCallsAreIdempotent) {
+    core::EventBus bus;
+    int callCount = 0;
+
+    bus.subscribe<TestEvent>([&](const TestEvent&) {
+        callCount++;
+    });
+    bus.publish_deferred(TestEvent{1});
+    bus.process_deferred();
+    EXPECT_EQ(callCount, 1);
+    bus.process_deferred();
+    EXPECT_EQ(callCount, 1);
+    bus.process_deferred();
+    EXPECT_EQ(callCount, 1);
+}
+
+TEST(EventBusTest, GameLikeScenario) {
+    core::EventBus bus;
+
+    int totalScore = 0;
+    bus.subscribe<TestEvent>([&](const TestEvent& evt) {
+        totalScore += evt.value;
+    });
+    std::vector<std::string> soundsPlayed;
+    bus.subscribe<AnotherTestEvent>([&](const AnotherTestEvent& evt) {
+        soundsPlayed.push_back(evt.message);
+    });
+    bus.publish(TestEvent{100});
+    bus.publish_deferred(AnotherTestEvent{"explosion.wav"});
+    bus.publish(TestEvent{50});
+    bus.publish_deferred(AnotherTestEvent{"coin.wav"});
+    EXPECT_EQ(totalScore, 150);
+    EXPECT_EQ(soundsPlayed.size(), 0);
+    bus.process_deferred();
+    EXPECT_EQ(totalScore, 150);
+    ASSERT_EQ(soundsPlayed.size(), 2);
+    EXPECT_EQ(soundsPlayed[0], "explosion.wav");
+    EXPECT_EQ(soundsPlayed[1], "coin.wav");
+}


### PR DESCRIPTION
This pull request introduces a new generic event bus system to the engine, enabling decoupled communication between systems using a publish/subscribe pattern. It includes a robust implementation with support for immediate and deferred event publishing, subscription management, and comprehensive unit tests to ensure reliability and correctness. The build system is updated to support building and running these tests using Google Test.

**Event System Implementation**

* Added a generic `EventBus` class to `engine/include/core/event/EventBus.hpp` and its implementation in `engine/src/core/event/EventBus.cpp`. The system supports subscribing to events, publishing events immediately or deferred, unsubscribing, clearing all subscriptions/events, and querying subscriber/deferred event counts. [[1]](diffhunk://#diff-19bd86f0580c11fed0b0302bf7c9efdf72d54b5fded3624b4e6c67d0ddc6e6a4R1-R110) [[2]](diffhunk://#diff-11ec99425405edc5164433b09f72d51ba509e8ea4dc05e3a849c627a12a8522dR1-R145)
* Introduced a base `Event` interface in `engine/include/core/event/Event.hpp` for type safety and polymorphism in the event system.

**Build System Integration**

* Updated the root `CMakeLists.txt` to add a `BUILD_TESTS` option and include the `tests` subdirectory when building tests. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR10) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR26-R29)
* Added `engine/src/core/event/EventBus.cpp` to the engine build for proper linkage.
* Created `tests/CMakeLists.txt` to build and run unit tests for the event bus using Google Test.

**Testing**

* Added comprehensive unit tests for the event bus in `tests/core/event/test_eventbus.cpp`, covering subscription, publishing (immediate and deferred), unsubscription, clearing, event data, and edge cases.