### PR TITLE
feat : adding windows complience into miniaudio file

### DIFF
--- a/engine/plugins/audio/miniaudio/src/MiniaudioPlugin.cpp
+++ b/engine/plugins/audio/miniaudio/src/MiniaudioPlugin.cpp
@@ -5,10 +5,18 @@
 ** MiniaudioPlugin - Miniaudio implementation of IAudioPlugin
 */
 
+// Prevent Windows.h from defining min/max macros
+#if defined(_WIN32) || defined(_WIN64)
+    #ifndef NOMINMAX
+        #define NOMINMAX
+    #endif
+#endif
+
 #define MINIAUDIO_IMPLEMENTATION
 #include "MiniaudioPlugin.hpp"
 #include <stdexcept>
 #include <iostream>
+#include <algorithm>
 
 namespace rtype {
 


### PR DESCRIPTION
This pull request introduces a small but important change to the `MiniaudioPlugin.cpp` file to improve compatibility with Windows builds. The update prevents potential macro conflicts caused by the inclusion of `Windows.h`.

Platform compatibility:

* Added a preprocessor block to define `NOMINMAX` on Windows platforms, preventing `Windows.h` from defining `min` and `max` macros that could interfere with standard library usage.