### PR TITLE
feat: adding the camke file fix we forgot find package for mini audio…

### DIFF
--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -13,9 +13,9 @@ target_include_directories(rtype_engine
         ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# Find Boost for Asio network plugin
+# Find Boost for Asio network plugin (using vcpkg)
 find_package(Boost REQUIRED COMPONENTS system)
-target_link_libraries(rtype_engine PUBLIC ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+target_link_libraries(rtype_engine PUBLIC Boost::system ${CMAKE_DL_LIBS})
 
 # # Find and link raylib
 # find_package(raylib QUIET)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -109,6 +109,7 @@ add_test(NAME AsioNetworkPluginTest COMMAND test_asio_network_plugin)
 set_property(TARGET test_asio_network_plugin PROPERTY CXX_STANDARD 20)
 
 # Raylib Graphics Plugin as shared library
+find_package(raylib REQUIRED)
 add_library(raylib_graphics SHARED
     ${CMAKE_SOURCE_DIR}/src/engine/src/plugins/graphics/raylib/RaylibGraphicsPlugin.cpp
 )


### PR DESCRIPTION
This pull request updates the CMake configuration for both the engine and test projects to improve dependency management and ensure proper linking of required libraries. The most significant changes involve how Boost and raylib are found and linked in the build system.

**Build system improvements:**

* Updated the way Boost is linked in `src/engine/CMakeLists.txt` by switching to `Boost::system` for more reliable and modern CMake integration.
* Added a `find_package(raylib REQUIRED)` directive in `tests/CMakeLists.txt` to explicitly require raylib for the test build, ensuring the graphics plugin test is correctly configured.