### PR TITLE
feat(ecs): add NetworkSystem with automatic server initialization

### DIFF
--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(rtype_engine
     src/ecs/systems/PhysiqueSystem.cpp
     src/ecs/systems/InputSystem.cpp
     src/ecs/systems/RenderSystem.cpp
+    src/ecs/systems/NetworkSystem.cpp
     src/core/event/EventBus.cpp
     src/plugin_manager/PluginManager.cpp
 )

--- a/src/engine/include/ecs/systems/NetworkSystem.hpp
+++ b/src/engine/include/ecs/systems/NetworkSystem.hpp
@@ -1,0 +1,54 @@
+/*
+** EPITECH PROJECT, 2025
+** Mirror-R-Type
+** File description:
+** NetworkSystem
+*/
+
+#ifndef NETWORKSYSTEM_HPP_
+#define NETWORKSYSTEM_HPP_
+
+#include "ecs/systems/ISystem.hpp"
+#include "ecs/Registry.hpp"
+#include "plugin_manager/INetworkPlugin.hpp"
+
+/**
+ * @brief System that handles network communication via INetworkPlugin
+ *
+ * This system manages network operations for both server and client modes.
+ * It processes network packets and synchronizes entity state across the network.
+ */
+class NetworkSystem : public ISystem {
+    private:
+        engine::INetworkPlugin* network_plugin;  // Reference to the plugin (non-owned)
+        bool is_server_mode;                     // True if running as server
+        uint16_t server_port;                    // Port to use in server mode
+
+    public:
+        /**
+         * @brief Constructor with a network plugin
+         * @param plugin Pointer to the network plugin to use
+         * @param server_mode True if system should operate in server mode
+         * @param port Port to use in server mode (default: 4242)
+         */
+        explicit NetworkSystem(engine::INetworkPlugin* plugin, bool server_mode = false, uint16_t port = 4242);
+        virtual ~NetworkSystem() = default;
+
+        void init(Registry& registry) override;
+        void shutdown() override;
+        void update(Registry& registry, float dt) override;
+
+        /**
+         * @brief Check if system is in server mode
+         * @return True if server mode, false if client mode
+         */
+        bool is_server() const { return is_server_mode; }
+
+        /**
+         * @brief Get the network plugin
+         * @return Pointer to the network plugin
+         */
+        engine::INetworkPlugin* get_plugin() const { return network_plugin; }
+};
+
+#endif /* !NETWORKSYSTEM_HPP_ */

--- a/src/engine/src/ecs/systems/NetworkSystem.cpp
+++ b/src/engine/src/ecs/systems/NetworkSystem.cpp
@@ -1,0 +1,77 @@
+/*
+** EPITECH PROJECT, 2025
+** Mirror-R-Type
+** File description:
+** NetworkSystem
+*/
+
+#include "ecs/systems/NetworkSystem.hpp"
+#include "ecs/Components.hpp"
+#include <iostream>
+
+NetworkSystem::NetworkSystem(engine::INetworkPlugin* plugin, bool server_mode, uint16_t port)
+    : network_plugin(plugin), is_server_mode(server_mode), server_port(port)
+{
+    if (!network_plugin) {
+        throw std::runtime_error("NetworkSystem: plugin cannot be null");
+    }
+}
+
+void NetworkSystem::init(Registry& registry)
+{
+    (void)registry;
+    std::cout << "NetworkSystem: Initialisation in " 
+              << (is_server_mode ? "SERVER" : "CLIENT") 
+              << " mode with " << network_plugin->get_name() << std::endl;
+    
+    // Start server automatically in server mode
+    if (is_server_mode) {
+        if (network_plugin->start_server(server_port)) {
+            std::cout << "NetworkSystem: Server started on port " << server_port << std::endl;
+        } else {
+            throw std::runtime_error("NetworkSystem: Failed to start server on port " + std::to_string(server_port));
+        }
+    }
+}
+
+void NetworkSystem::shutdown()
+{
+    std::cout << "NetworkSystem: Shutdown" << std::endl;
+    
+    if (is_server_mode && network_plugin->is_server_running()) {
+        network_plugin->stop_server();
+    } else if (!is_server_mode && network_plugin->is_connected()) {
+        network_plugin->disconnect();
+    }
+}
+
+void NetworkSystem::update(Registry& registry, float dt)
+{
+    (void)registry;
+    
+    // Update the network plugin (poll for events)
+    network_plugin->update(dt);
+    
+    // Receive and process packets
+    auto packets = network_plugin->receive();
+    
+    for (const auto& packet : packets) {
+        // Process received packets
+        // This is where you would deserialize packet data and update entities
+        // For now, just log that we received a packet
+        if (!packet.data.empty()) {
+            if (is_server_mode) {
+                std::cout << "NetworkSystem [SERVER]: Received packet from client " 
+                          << packet.sender_id << " (" << packet.data.size() << " bytes)" << std::endl;
+            } else {
+                std::cout << "NetworkSystem [CLIENT]: Received packet from server (" 
+                          << packet.data.size() << " bytes)" << std::endl;
+            }
+        }
+    }
+    
+    // TODO: Add entity synchronization logic here
+    // - Serialize entity state (Position, Velocity, etc.)
+    // - Send updates to clients (server mode) or server (client mode)
+    // - Handle interpolation/prediction for smooth gameplay
+}


### PR DESCRIPTION
- Add NetworkSystem as an ECS system to handle network communication
- Integrate INetworkPlugin interface for flexible network backend
- Automatically start server on init() when in server mode
- Support configurable port (default: 4242)
- Handle both server and client modes
- Process incoming network packets in update() cycle
- Add proper shutdown for server and client connections
- Update CMakeLists.txt to include NetworkSystem compilation