### PR TITLE
feat: --help usage and exemple

### DIFF
--- a/src/r-type/client/src/main.cpp
+++ b/src/r-type/client/src/main.cpp
@@ -9,6 +9,7 @@
 #include "protocol/NetworkConfig.hpp"
 #include <iostream>
 #include <string>
+#include <cstring>
 
 #include "ecs/systems/AudioSystem.hpp"
 #include "systems/HealthSystem.hpp"
@@ -24,7 +25,40 @@
 #include "plugin_manager/IInputPlugin.hpp"
 #include "plugin_manager/IAudioPlugin.hpp"
 
+void print_help(const char* program_name) {
+    std::cout << "=== R-Type Client ===\n\n";
+    std::cout << "USAGE:\n";
+    std::cout << "  " << program_name << " [OPTIONS] [HOST] [PORT] [PLAYER_NAME]\n\n";
+    std::cout << "OPTIONS:\n";
+    std::cout << "  -h, --help              Show this help message and exit\n\n";
+    std::cout << "ARGUMENTS:\n";
+    std::cout << "  HOST                    Server IP address or hostname\n";
+    std::cout << "                          Default: 127.0.0.1\n\n";
+    std::cout << "  PORT                    Server TCP port number\n";
+    std::cout << "                          Default: " << rtype::protocol::config::DEFAULT_TCP_PORT << "\n\n";
+    std::cout << "  PLAYER_NAME             Your player name (displayed in lobby)\n";
+    std::cout << "                          Default: Pilot\n\n";
+    std::cout << "EXAMPLES:\n";
+    std::cout << "  " << program_name << "\n";
+    std::cout << "      Connect to localhost:" << rtype::protocol::config::DEFAULT_TCP_PORT << " as 'Pilot'\n\n";
+    std::cout << "  " << program_name << " 192.168.1.100\n";
+    std::cout << "      Connect to 192.168.1.100:" << rtype::protocol::config::DEFAULT_TCP_PORT << " as 'Pilot'\n\n";
+    std::cout << "  " << program_name << " 192.168.1.100 4242 Alice\n";
+    std::cout << "      Connect to 192.168.1.100:4242 as 'Alice'\n\n";
+    std::cout << "CONTROLS:\n";
+    std::cout << "  Arrow Keys              Move spaceship\n";
+    std::cout << "  Space / Left Click      Fire weapon\n";
+    std::cout << "  ESC                     Quit game\n\n";
+}
+
 int main(int argc, char* argv[]) {
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "-h") == 0 || std::strcmp(argv[i], "--help") == 0) {
+            print_help(argv[0]);
+            return 0;
+        }
+    }
+
     const int SCREEN_WIDTH = 1920;
     const int SCREEN_HEIGHT = 1080;
     std::string host = "127.0.0.1";
@@ -37,15 +71,22 @@ int main(int argc, char* argv[]) {
         try {
             tcp_port = static_cast<uint16_t>(std::stoi(argv[2]));
         } catch (const std::exception& e) {
-            std::cerr << "Invalid TCP port: " << e.what() << '\n';
+            std::cerr << "Error: Invalid TCP port: " << e.what() << '\n';
+            std::cerr << "Use --help for usage information\n";
             return 1;
         }
     }
     if (argc > 3)
         player_name = argv[3];
+
+    std::cout << "=== R-Type Network Client ===\n";
+    std::cout << "Server: " << host << ":" << tcp_port << "\n";
+    std::cout << "Player: " << player_name << "\n\n";
+
     rtype::client::ClientGame game(SCREEN_WIDTH, SCREEN_HEIGHT);
     if (!game.initialize(host, tcp_port, player_name)) {
         std::cerr << "Failed to initialize game\n";
+        std::cerr << "Use --help for usage information\n";
         return 1;
     }
     game.run();

--- a/src/r-type/server/src/main.cpp
+++ b/src/r-type/server/src/main.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <csignal>
 #include <memory>
+#include <cstring>
 
 // Global server instance for signal handling
 static std::unique_ptr<rtype::server::Server> g_server;
@@ -24,38 +25,94 @@ void signal_handler(int signal) {
     }
 }
 
+void print_help(const char* program_name) {
+    std::cout << "=== R-Type Server ===\n\n";
+    std::cout << "USAGE:\n";
+    std::cout << "  " << program_name << " [OPTIONS] [TCP_PORT] [UDP_PORT]\n\n";
+    std::cout << "OPTIONS:\n";
+    std::cout << "  -h, --help              Show this help message and exit\n";
+    std::cout << "  -n, --network           Listen on all network interfaces (0.0.0.0)\n";
+    std::cout << "                          By default, server listens on localhost only (127.0.0.1)\n\n";
+    std::cout << "ARGUMENTS:\n";
+    std::cout << "  TCP_PORT                TCP port for connections and lobby management\n";
+    std::cout << "                          Default: " << rtype::server::config::DEFAULT_TCP_PORT << "\n\n";
+    std::cout << "  UDP_PORT                UDP port for game state synchronization\n";
+    std::cout << "                          Default: " << rtype::server::config::DEFAULT_UDP_PORT << "\n\n";
+    std::cout << "EXAMPLES:\n";
+    std::cout << "  " << program_name << "\n";
+    std::cout << "      Start server on localhost with default ports\n";
+    std::cout << "      (TCP:" << rtype::server::config::DEFAULT_TCP_PORT << ", UDP:" << rtype::server::config::DEFAULT_UDP_PORT << ")\n\n";
+    std::cout << "  " << program_name << " -n\n";
+    std::cout << "      Start server on all interfaces (0.0.0.0) with default ports\n\n";
+    std::cout << "  " << program_name << " 4242 4243\n";
+    std::cout << "      Start server on localhost with TCP:4242 and UDP:4243\n\n";
+    std::cout << "  " << program_name << " 4242 4243 -n\n";
+    std::cout << "      Start server on all interfaces with TCP:4242 and UDP:4243\n\n";
+    std::cout << "ARCHITECTURE:\n";
+    std::cout << "  The server uses a hybrid TCP/UDP architecture:\n";
+    std::cout << "  - TCP: Reliable connection, lobby, chat, game start/end\n";
+    std::cout << "  - UDP: Real-time game state (position, velocity, actions)\n\n";
+    std::cout << "NOTES:\n";
+    std::cout << "  - Use -n/--network flag to make server accessible from other machines\n";
+    std::cout << "  - Press Ctrl+C to stop the server gracefully\n";
+    std::cout << "  - Make sure firewall allows the specified ports\n\n";
+}
+
 int main(int argc, char* argv[]) {
+    // Check for help flag first
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "-h") == 0 || std::strcmp(argv[i], "--help") == 0) {
+            print_help(argv[0]);
+            return 0;
+        }
+    }
+
     // Parse command line arguments
     uint16_t tcp_port = rtype::server::config::DEFAULT_TCP_PORT;
     uint16_t udp_port = rtype::server::config::DEFAULT_UDP_PORT;
     bool listen_on_all_interfaces = false;
 
-    if (argc > 1) {
-        try {
-            tcp_port = static_cast<uint16_t>(std::stoi(argv[1]));
-        } catch (const std::exception& e) {
-            std::cerr << "Invalid TCP port number: " << argv[1] << "\n";
-            std::cerr << "Usage: " << argv[0] << " [tcp_port] [udp_port] [--network|-n]\n";
-            std::cerr << "  --network, -n : Listen on all network interfaces (0.0.0.0) instead of localhost\n";
-            return 1;
-        }
-    }
-    if (argc > 2) {
-        try {
-            udp_port = static_cast<uint16_t>(std::stoi(argv[2]));
-        } catch (const std::exception& e) {
-            std::cerr << "Invalid UDP port number: " << argv[2] << "\n";
-            std::cerr << "Usage: " << argv[0] << " [tcp_port] [udp_port] [--network|-n]\n";
-            std::cerr << "  --network, -n : Listen on all network interfaces (0.0.0.0) instead of localhost\n";
-            return 1;
-        }
-    }
     // Check for network flag
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
         if (arg == "--network" || arg == "-n") {
             listen_on_all_interfaces = true;
             break;
+        }
+    }
+
+    // Parse ports (skip network flags)
+    int port_arg_idx = 1;
+    if (argc > 1) {
+        std::string first_arg = argv[1];
+        if (first_arg == "--network" || first_arg == "-n") {
+            port_arg_idx = 2;
+        }
+
+        if (argc > port_arg_idx) {
+            std::string port_str = argv[port_arg_idx];
+            if (port_str != "--network" && port_str != "-n") {
+                try {
+                    tcp_port = static_cast<uint16_t>(std::stoi(port_str));
+                } catch (const std::exception& e) {
+                    std::cerr << "Error: Invalid TCP port number: " << port_str << "\n";
+                    std::cerr << "Use --help for usage information\n";
+                    return 1;
+                }
+            }
+        }
+    }
+
+    if (argc > port_arg_idx + 1) {
+        std::string port_str = argv[port_arg_idx + 1];
+        if (port_str != "--network" && port_str != "-n") {
+            try {
+                udp_port = static_cast<uint16_t>(std::stoi(port_str));
+            } catch (const std::exception& e) {
+                std::cerr << "Error: Invalid UDP port number: " << port_str << "\n";
+                std::cerr << "Use --help for usage information\n";
+                return 1;
+            }
         }
     }
 


### PR DESCRIPTION
This pull request enhances the user experience for both the R-Type client and server applications by adding comprehensive command-line help messages, improving argument parsing, and providing clearer error reporting. These changes make it easier for users to understand how to launch and configure both programs, as well as to troubleshoot common issues.

**Command-line help and usage improvements:**

* Added detailed `print_help` functions to both `src/r-type/client/src/main.cpp` and `src/r-type/server/src/main.cpp`, which provide usage instructions, argument descriptions, examples, and additional notes about controls or architecture. The help message is shown when the user passes `-h` or `--help`. [[1]](diffhunk://#diff-ecccfdd145c2df67c85f0f2a168ca8c51d3289afcea4f1f9fabef97b21800103R28-R61) [[2]](diffhunk://#diff-94aac0ec851d611a06fa8a5edc8cfed9d30fc7dad8e0ca74438c358b8d4743aeR28-L59)
* Improved error messages for invalid port arguments in both client and server, now suggesting the use of the `--help` flag for further guidance. [[1]](diffhunk://#diff-ecccfdd145c2df67c85f0f2a168ca8c51d3289afcea4f1f9fabef97b21800103L40-R89) [[2]](diffhunk://#diff-94aac0ec851d611a06fa8a5edc8cfed9d30fc7dad8e0ca74438c358b8d4743aeR28-L59)

**Argument parsing and user feedback:**

* Enhanced command-line argument parsing in the server to properly handle the `--network`/`-n` flag regardless of argument order, and to robustly parse TCP/UDP ports while skipping flags.
* Added startup summary output in the client to clearly indicate the server address, port, and player name being used.

**Codebase maintenance:**

* Included the `<cstring>` header in both client and server `main.cpp` files to support string comparison for argument parsing. [[1]](diffhunk://#diff-ecccfdd145c2df67c85f0f2a168ca8c51d3289afcea4f1f9fabef97b21800103R12) [[2]](diffhunk://#diff-94aac0ec851d611a06fa8a5edc8cfed9d30fc7dad8e0ca74438c358b8d4743aeR13)