### PR TITLE
feat: Implement global score synchronization

### DIFF
--- a/src/r-type/client/include/NetworkClient.hpp
+++ b/src/r-type/client/include/NetworkClient.hpp
@@ -186,6 +186,11 @@ public:
      */
     void set_on_wave_complete(std::function<void(const protocol::ServerWaveCompletePayload&)> callback);
 
+    /**
+     * @brief Set callback for score update events
+     */
+    void set_on_score_update(std::function<void(const protocol::ServerScoreUpdatePayload&)> callback);
+
     // ============== Getters ==============
 
     uint32_t get_player_id() const { return player_id_; }
@@ -211,6 +216,7 @@ private:
     void handle_game_over(const std::vector<uint8_t>& payload);
     void handle_wave_start(const std::vector<uint8_t>& payload);
     void handle_wave_complete(const std::vector<uint8_t>& payload);
+    void handle_score_update(const std::vector<uint8_t>& payload);
 
     // UDP connection after game start
     void connect_udp(uint16_t udp_port);
@@ -251,6 +257,7 @@ private:
     std::function<void()> on_disconnected_;
     std::function<void(const protocol::ServerWaveStartPayload&)> on_wave_start_;
     std::function<void(const protocol::ServerWaveCompletePayload&)> on_wave_complete_;
+    std::function<void(const protocol::ServerScoreUpdatePayload&)> on_score_update_;
 };
 
 }

--- a/src/r-type/client/src/ClientGame.cpp
+++ b/src/r-type/client/src/ClientGame.cpp
@@ -309,6 +309,17 @@ void ClientGame::setup_network_callbacks() {
         ctrl.allWavesCompleted = wave.all_waves_complete != 0;
     });
 
+    network_client_->set_on_score_update([this](const protocol::ServerScoreUpdatePayload& score) {
+        uint32_t local_server_id = entity_manager_->get_local_player_entity_id();
+        if (entity_manager_->has_entity(local_server_id)) {
+            Entity entity = entity_manager_->get_entity(local_server_id);
+            auto& scores = registry_->get_components<Score>();
+            if (scores.has_entity(entity)) {
+                scores[entity].value = score.new_total_score;
+            }
+        }
+    });
+
     network_client_->set_on_projectile_spawn([this](const protocol::ServerProjectileSpawnPayload& proj) {
         uint32_t proj_id = ntohl(proj.projectile_id);
         uint32_t owner_id = ntohl(proj.owner_id);

--- a/src/r-type/server/include/GameSession.hpp
+++ b/src/r-type/server/include/GameSession.hpp
@@ -110,6 +110,7 @@ private:
     void on_entity_spawned(uint32_t session_id, const std::vector<uint8_t>& spawn_data) override;
     void on_entity_destroyed(uint32_t session_id, uint32_t entity_id) override;
     void on_projectile_spawned(uint32_t session_id, const std::vector<uint8_t>& projectile_data) override;
+    void on_score_updated(uint32_t session_id, const std::vector<uint8_t>& score_data) override;
 
     // Internal helpers
     void spawn_player_entity(GamePlayer& player);

--- a/src/r-type/server/include/Server.hpp
+++ b/src/r-type/server/include/Server.hpp
@@ -85,6 +85,7 @@ private:
     void on_wave_start(uint32_t session_id, const std::vector<uint8_t>& wave_data) override;
     void on_wave_complete(uint32_t session_id, const std::vector<uint8_t>& wave_data) override;
     void on_game_over(uint32_t session_id, const std::vector<uint32_t>& player_ids, bool is_victory) override;
+    void on_score_update(uint32_t session_id, const std::vector<uint8_t>& score_data) override;
 
     // === Internal Methods ===
     void on_tcp_client_disconnected(uint32_t client_id);

--- a/src/r-type/server/include/ServerNetworkSystem.hpp
+++ b/src/r-type/server/include/ServerNetworkSystem.hpp
@@ -90,6 +90,7 @@ private:
     void broadcast_pending_spawns();
     void broadcast_pending_destroys();
     void broadcast_pending_projectiles();
+    void broadcast_pending_scores();
     void spawn_projectile(Registry& registry, Entity owner, float x, float y);
     void spawn_enemy_projectile(Registry& registry, Entity owner, float x, float y);
     void update_enemy_shooting(Registry& registry, float dt);
@@ -109,6 +110,7 @@ private:
     std::queue<protocol::ServerEntitySpawnPayload> pending_spawns_;
     std::queue<uint32_t> pending_destroys_;
     std::queue<protocol::ServerProjectileSpawnPayload> pending_projectiles_;
+    std::queue<protocol::ServerScoreUpdatePayload> pending_scores_;
 
     // Cooldown tracking
     std::unordered_map<uint32_t, float> shoot_cooldowns_;
@@ -122,6 +124,7 @@ private:
 
     // Event subscription ID
     core::EventBus::SubscriptionId shotFiredSubId_;
+    core::EventBus::SubscriptionId enemyKilledSubId_;
 
     // Player ID -> Entity mapping (owned by GameSession)
     std::unordered_map<uint32_t, Entity>* player_entities_ = nullptr;

--- a/src/r-type/server/include/interfaces/IGameSessionListener.hpp
+++ b/src/r-type/server/include/interfaces/IGameSessionListener.hpp
@@ -75,6 +75,13 @@ public:
      * @param is_victory True if players won, false if all players died
      */
     virtual void on_game_over(uint32_t session_id, const std::vector<uint32_t>& player_ids, bool is_victory) = 0;
+
+    /**
+     * @brief Called when score is updated
+     * @param session_id The game session
+     * @param score_data Serialized score data
+     */
+    virtual void on_score_update(uint32_t session_id, const std::vector<uint8_t>& score_data) = 0;
 };
 
 }

--- a/src/r-type/server/include/interfaces/INetworkSystemListener.hpp
+++ b/src/r-type/server/include/interfaces/INetworkSystemListener.hpp
@@ -44,6 +44,11 @@ public:
      * @brief Called when a projectile spawns
      */
     virtual void on_projectile_spawned(uint32_t session_id, const std::vector<uint8_t>& projectile_data) = 0;
+
+    /**
+     * @brief Called when score is updated
+     */
+    virtual void on_score_updated(uint32_t session_id, const std::vector<uint8_t>& score_data) = 0;
 };
 
 }

--- a/src/r-type/server/src/GameSession.cpp
+++ b/src/r-type/server/src/GameSession.cpp
@@ -9,6 +9,7 @@
 #include "ServerConfig.hpp"
 #include "systems/ShootingSystem.hpp"
 #include "systems/BonusSystem.hpp"
+#include "systems/ScoreSystem.hpp"
 #include "components/CombatHelpers.hpp"
 
 #undef ENEMY_BASIC_SPEED
@@ -80,9 +81,11 @@ GameSession::GameSession(uint32_t session_id, protocol::GameMode game_mode,
     registry_.register_system<HealthSystem>();
     registry_.register_system<ShootingSystem>();
     registry_.register_system<BonusSystem>();
+    registry_.register_system<ScoreSystem>();
 
     registry_.get_system<ShootingSystem>().init(registry_);
     registry_.get_system<BonusSystem>().init(registry_);
+    registry_.get_system<ScoreSystem>().init(registry_);
 
     // Register ServerNetworkSystem BEFORE DestroySystem
     registry_.register_system<ServerNetworkSystem>(session_id_, config::SNAPSHOT_INTERVAL);
@@ -399,6 +402,12 @@ void GameSession::on_projectile_spawned(uint32_t session_id, const std::vector<u
 {
     if (listener_)
         listener_->on_projectile_spawn(session_id, projectile_data);
+}
+
+void GameSession::on_score_updated(uint32_t session_id, const std::vector<uint8_t>& score_data)
+{
+    if (listener_)
+        listener_->on_score_update(session_id, score_data);
 }
 
 // === Internal Helpers ===

--- a/src/r-type/server/src/Server.cpp
+++ b/src/r-type/server/src/Server.cpp
@@ -421,6 +421,15 @@ void Server::on_wave_complete(uint32_t session_id, const std::vector<uint8_t>& w
                                             wave_data, session->get_player_ids(), connected_clients_);
 }
 
+void Server::on_score_update(uint32_t session_id, const std::vector<uint8_t>& score_data)
+{
+    auto* session = session_manager_->get_session(session_id);
+    if (!session)
+        return;
+    packet_sender_->broadcast_udp_to_session(session_id, protocol::PacketType::SERVER_SCORE_UPDATE,
+                                            score_data, session->get_player_ids(), connected_clients_);
+}
+
 void Server::on_game_over(uint32_t session_id, const std::vector<uint32_t>& player_ids, bool is_victory)
 {
     std::cout << "[Server] Game over for session " << session_id


### PR DESCRIPTION
This commit addresses the issue where the global score was not being updated or displayed on the client side.

- Server-side:
  - Registered  in  to ensure score components are updated on the server.
  - Modified  to subscribe to , queue  packets, and broadcast them to clients.
  - Extended  and  to include callbacks.
  - Implemented  in  and  to propagate the score update through the network stack.

- Client-side:
  - Modified  to handle incoming  packets.
  - Added a new  callback to .
  - Updated  to subscribe to this callback and update the component of the local player entity, ensuring the HUD reflects the global score.