### PR TITLE
Fix ci

### DIFF
--- a/tests/ecs/test_shooting_system.cpp
+++ b/tests/ecs/test_shooting_system.cpp
@@ -14,6 +14,10 @@
 #include "components/CombatConfig.hpp"
 #include <cmath>
 
+#ifndef M_PI
+    #define M_PI 3.14159265358979323846
+#endif
+
 // ============================================================================
 // SHOOTING SYSTEM TESTS WITH WEAPON SYSTEM
 // ============================================================================


### PR DESCRIPTION
This pull request introduces a minor update to the `tests/ecs/test_shooting_system.cpp` file to ensure the mathematical constant `M_PI` is defined if it is not already present in the environment.

* Added a preprocessor check and definition for `M_PI` to avoid compilation issues on platforms where it may be missing.