### PR TITLE
fix(game): correct victory/defeat conditions and display

### DIFF
--- a/src/r-type/client/src/ClientGame.cpp
+++ b/src/r-type/client/src/ClientGame.cpp
@@ -579,6 +579,8 @@ void ClientGame::run() {
                        current_screen == GameScreen::CREATE_ROOM ||
                        current_screen == GameScreen::BROWSE_ROOMS ||
                        current_screen == GameScreen::ROOM_LOBBY);
+        bool in_result = (current_screen == GameScreen::VICTORY ||
+                         current_screen == GameScreen::DEFEAT);
         entity_manager_->update_projectiles(dt);
         entity_manager_->update_name_tags();
 
@@ -695,16 +697,15 @@ void ClientGame::run() {
             }
 
             menu_manager_->draw(graphics_plugin_);
+        } else if (in_result) {
+            // Result screen (victory/defeat) - only render, no game logic
+            registry_->run_systems(dt);
         } else {
             // Game screen - run game systems
-            entity_manager_->update_projectiles(dt);
-            entity_manager_->update_name_tags();
-
-        if (registry_->has_system<LocalPredictionSystem>()) {
-            auto& prediction = registry_->get_system<LocalPredictionSystem>();
-            prediction.set_current_time(current_time_);
-        }
-        registry_->run_systems(dt);
+            if (registry_->has_system<LocalPredictionSystem>()) {
+                auto& prediction = registry_->get_system<LocalPredictionSystem>();
+                prediction.set_current_time(current_time_);
+            }
             registry_->run_systems(dt);
         }
 

--- a/src/r-type/client/src/ScreenManager.cpp
+++ b/src/r-type/client/src/ScreenManager.cpp
@@ -133,11 +133,45 @@ void ScreenManager::show_waiting_screen() {
 void ScreenManager::show_result(bool victory) {
     auto& sprites = registry_.get_components<Sprite>();
     auto& texts = registry_.get_components<UIText>();
+    auto& positions = registry_.get_components<Position>();
 
-    if (sprites.has_entity(result_screen_bg_))
+    // Recreate background sprite if needed
+    if (!sprites.has_entity(result_screen_bg_) || !positions.has_entity(result_screen_bg_)) {
+        result_screen_bg_ = registry_.spawn_entity();
+        registry_.add_component(result_screen_bg_, Position{0.0f, 0.0f});
+        registry_.add_component(result_screen_bg_, Sprite{
+            menu_background_texture_,
+            static_cast<float>(screen_width_),
+            static_cast<float>(screen_height_),
+            0.0f,
+            engine::Color::White,
+            0.0f,
+            0.0f,
+            200
+        });
+    } else {
         sprites[result_screen_bg_].tint = engine::Color::White;
+    }
 
-    if (texts.has_entity(result_screen_text_)) {
+    // Recreate result text if needed
+    if (!texts.has_entity(result_screen_text_) || !positions.has_entity(result_screen_text_)) {
+        result_screen_text_ = registry_.spawn_entity();
+        registry_.add_component(result_screen_text_, Position{
+            static_cast<float>(screen_width_) / 2.0f - 150.0f,
+            static_cast<float>(screen_height_) / 2.0f - 50.0f
+        });
+        registry_.add_component(result_screen_text_, UIText{
+            victory ? "VICTOIRE !" : "DEFAITE...",
+            victory ? engine::Color{100, 255, 100, 255} : engine::Color{255, 100, 100, 255},
+            engine::Color{0, 0, 0, 200},
+            48,
+            true,
+            4.0f,
+            4.0f,
+            true,
+            201
+        });
+    } else {
         texts[result_screen_text_].text = victory ? "VICTOIRE !" : "DEFAITE...";
         texts[result_screen_text_].color = victory
             ? engine::Color{100, 255, 100, 255}

--- a/src/r-type/server/src/GameSession.cpp
+++ b/src/r-type/server/src/GameSession.cpp
@@ -205,11 +205,14 @@ void GameSession::update(float delta_time)
     check_offscreen_enemies();
 
     if (wave_manager_.all_waves_complete() && is_active_) {
-        std::cout << "[GameSession " << session_id_ << "] All waves complete - game victory!\n";
-        is_active_ = false;
-        if (listener_)
-            listener_->on_game_over(session_id_, get_player_ids(), true);  // Victory
-        return;
+        auto& enemies = registry_.get_components<Enemy>();
+        if (enemies.size() == 0) {
+            std::cout << "[GameSession " << session_id_ << "] All waves complete - game victory!\n";
+            is_active_ = false;
+            if (listener_)
+                listener_->on_game_over(session_id_, get_player_ids(), true);  // Victory
+            return;
+        }
     }
 
     check_game_over();

--- a/src/r-type/server/src/Server.cpp
+++ b/src/r-type/server/src/Server.cpp
@@ -431,15 +431,15 @@ void Server::on_game_over(uint32_t session_id, const std::vector<uint32_t>& play
 {
     std::cout << "[Server] Game over for session " << session_id
               << (is_victory ? " - VICTORY!" : " - DEFEAT!") << "\n";
-    auto* session = session_manager_->get_session(session_id);
+
     protocol::ServerGameOverPayload game_over;
     game_over.result = is_victory ? protocol::GameResult::VICTORY : protocol::GameResult::DEFEAT;
 
-    if (session) {
-        packet_sender_->broadcast_udp_to_session(session_id, protocol::PacketType::SERVER_GAME_OVER,
-                                                serialize(game_over), session->get_player_ids(),
-                                                connected_clients_);
-    }
+    // Send message using player_ids parameter directly (session might be deleted by cleanup)
+    packet_sender_->broadcast_udp_to_session(session_id, protocol::PacketType::SERVER_GAME_OVER,
+                                            serialize(game_over), player_ids,
+                                            connected_clients_);
+
     for (uint32_t player_id : player_ids) {
         auto client_it = player_to_client_.find(player_id);
         if (client_it == player_to_client_.end())


### PR DESCRIPTION
- Server: use player_ids parameter directly in on_game_over to prevent message loss when session is cleaned up
- Server: add enemy count verification to victory condition (all waves complete AND no enemies alive)
- Client: add victory/defeat screen state handling in main game loop
- Client: recreate result screen UI entities on-demand if destroyed during game start

This fixes two critical bugs:
1. Victory/defeat messages never displayed because SERVER_GAME_OVER was not sent (session deleted before broadcast)
2. Victory triggered prematurely when last wave started instead of when all enemies killed