### PR TITLE
feat: fixing game state issue

### DIFF
--- a/src/r-type/client/include/ScreenManager.hpp
+++ b/src/r-type/client/include/ScreenManager.hpp
@@ -107,6 +107,7 @@ private:
 
     void hide_waiting_screen();
     void show_waiting_screen();
+    void hide_result_screen();
     void load_result_textures();
 };
 

--- a/src/r-type/client/src/ClientGame.cpp
+++ b/src/r-type/client/src/ClientGame.cpp
@@ -75,6 +75,14 @@ bool ClientGame::initialize(const std::string& host, uint16_t tcp_port, const st
 
     // Set callback for back to menu button
     screen_manager_->set_back_to_menu_callback([this]() {
+        // Reset GameState to PLAYING so player can start a new game
+        auto& gameStates = registry_->get_components<GameState>();
+        for (size_t i = 0; i < gameStates.size(); ++i) {
+            Entity entity = gameStates.get_entity_at(i);
+            gameStates[entity].currentState = GameStateType::PLAYING;
+            gameStates[entity].finalScore = 0;
+        }
+
         // Reset to main menu
         menu_manager_->set_screen(GameScreen::MAIN_MENU);
         screen_manager_->set_screen(GameScreen::MAIN_MENU);
@@ -450,7 +458,7 @@ void ClientGame::setup_network_callbacks() {
             case 3: mapIdStr = "bydo_mothership"; break;
             default: mapIdStr = "nebula_outpost"; break;
         }
-        
+
         // Load the selected map
         load_map(mapIdStr);
         if (chunk_manager_) {
@@ -464,6 +472,14 @@ void ClientGame::setup_network_callbacks() {
         Entity status_entity = screen_manager_->get_status_entity();
         if (texts.has_entity(status_entity))
             texts[status_entity].active = false;
+
+        // Reset GameState to PLAYING for the new game
+        auto& gameStates = registry_->get_components<GameState>();
+        for (size_t i = 0; i < gameStates.size(); ++i) {
+            Entity entity = gameStates.get_entity_at(i);
+            gameStates[entity].currentState = GameStateType::PLAYING;
+            gameStates[entity].finalScore = 0;
+        }
 
         auto& wave_controllers = registry_->get_components<WaveController>();
         if (wave_controllers.has_entity(wave_tracker_)) {

--- a/src/r-type/client/src/ScreenManager.cpp
+++ b/src/r-type/client/src/ScreenManager.cpp
@@ -98,10 +98,19 @@ void ScreenManager::set_screen(GameScreen screen) {
             break;
         case GameScreen::PLAYING:
             hide_waiting_screen();
+            hide_result_screen();
             break;
         case GameScreen::VICTORY:
         case GameScreen::DEFEAT:
             // Result screens are shown via show_result()
+            break;
+        case GameScreen::MAIN_MENU:
+        case GameScreen::CREATE_ROOM:
+        case GameScreen::BROWSE_ROOMS:
+        case GameScreen::ROOM_LOBBY:
+            // Hide game screens when returning to menu
+            hide_waiting_screen();
+            hide_result_screen();
             break;
     }
 }
@@ -124,6 +133,18 @@ void ScreenManager::show_waiting_screen() {
         sprites[waiting_screen_bg_].tint = engine::Color::White;
     if (texts.has_entity(waiting_screen_text_))
         texts[waiting_screen_text_].active = true;
+}
+
+void ScreenManager::hide_result_screen() {
+    auto& sprites = registry_.get_components<Sprite>();
+
+    // Hide the result screen background by making it transparent
+    if (sprites.has_entity(result_screen_bg_))
+        sprites[result_screen_bg_].tint = engine::Color{255, 255, 255, 0};
+
+    // Disable the back to menu button
+    if (back_to_menu_button_)
+        back_to_menu_button_->set_enabled(false);
 }
 
 void ScreenManager::load_result_textures() {

--- a/src/r-type/server/src/Server.cpp
+++ b/src/r-type/server/src/Server.cpp
@@ -314,6 +314,17 @@ void Server::on_game_start(uint32_t lobby_id, const std::vector<uint32_t>& playe
             continue;
         uint32_t client_id = client_it->second;
         auto& player_info = connected_clients_[client_id];
+
+        // Remove player from any previous session before adding to new one
+        uint32_t old_session_id = player_info.session_id;
+        if (old_session_id != 0) {
+            auto* old_session = session_manager_->get_session(old_session_id);
+            if (old_session) {
+                std::cout << "[Server] Removing player " << player_id << " from old session " << old_session_id << "\n";
+                old_session->remove_player(player_id);
+            }
+        }
+
         player_info.in_lobby = false;
         player_info.lobby_id = 0;
         player_info.in_game = true;


### PR DESCRIPTION
This pull request improves the handling of game state transitions and screen management in both the client and server code. The main focus is on ensuring that screens are properly reset when navigating between game states, and that player session data is correctly managed when starting new games.

**Client-side improvements to game state and screen management:**

* When returning to the main menu or starting a new game, the `GameState` for each entity is reset to `PLAYING` and the final score is cleared, preventing stale state from affecting new sessions. [[1]](diffhunk://#diff-538ae0bb275f61845e460567cd929ab5c5885f9d0ba291668319957d2508637bR78-R85) [[2]](diffhunk://#diff-538ae0bb275f61845e460567cd929ab5c5885f9d0ba291668319957d2508637bR476-R483)
* The `ScreenManager` now includes a `hide_result_screen()` method to hide the result screen and disable the "back to menu" button, ensuring that result screens do not persist when switching screens. [[1]](diffhunk://#diff-801bb2c8d018ef8b984a640b476cf0716f4cae1f7252b347123c9dabfda1bd62R110) [[2]](diffhunk://#diff-3888d65a9720eace7e3ab9bf2d39e06088127c748b734b6d51507f5dc0deddcdR138-R149)
* The `set_screen()` method in `ScreenManager` has been updated to call `hide_result_screen()` and `hide_waiting_screen()` when appropriate, such as when returning to the main menu or entering the playing state.

**Server-side session management:**

* When starting a new game, the server now removes a player from any previous session before adding them to the new one, preventing players from being associated with multiple sessions at once.