### PR TITLE
feat(admin): implement Tier 2 game control commands and console overlay

### DIFF
--- a/docs/PROTOCOL.txt
+++ b/docs/PROTOCOL.txt
@@ -41,6 +41,7 @@ Table of Contents
       5.5 World State Payloads ..................................... 29
       5.6 Entity Event Payloads .................................... 32
       5.7 Game Mechanics Payloads .................................. 35
+      5.8 Admin System Payloads .................................... 38
    6. Communication Patterns ....................................... 41
       6.1 Connection Establishment ................................. 41
       6.2 Lobby and Matchmaking .................................... 42
@@ -260,6 +261,10 @@ Table of Contents
    0x22    | CLIENT_LEAVE_ROOM         | Leave current custom room
    0x23    | CLIENT_REQUEST_ROOM_LIST  | Request list of rooms
    0x24    | CLIENT_START_GAME         | Start game (host only)
+   0x25    | CLIENT_SET_PLAYER_NAME    | Change player name in lobby
+   0x26    | CLIENT_SET_PLAYER_SKIN    | Change player skin in lobby
+   0x30    | CLIENT_ADMIN_AUTH         | Admin authentication request
+   0x31    | CLIENT_ADMIN_COMMAND      | Admin command execution
 
 4.3 Server-to-Client Packets
 
@@ -292,6 +297,12 @@ Table of Contents
    0xC3    | SERVER_WAVE_COMPLETE         | Wave completed
    0xC5    | SERVER_PLAYER_RESPAWN        | Player respawned
    0xC6    | SERVER_GAME_OVER             | Game session ended
+   0x96    | SERVER_PLAYER_NAME_UPDATED   | Player name changed in room
+   0x97    | SERVER_PLAYER_SKIN_UPDATED   | Player skin changed in room
+   0xF0    | SERVER_ADMIN_AUTH_RESULT     | Admin authentication result
+   0xF1    | SERVER_ADMIN_COMMAND_RESULT  | Admin command execution result
+   0xF2    | SERVER_ADMIN_NOTIFICATION    | Server-wide admin notification
+   0xF3    | SERVER_KICK_NOTIFICATION     | Player kicked by admin
 
 5. Payload Formats
 
@@ -1171,6 +1182,149 @@ Table of Contents
    Kills       | 2 bytes | 10     | Enemies killed
 
    Total Size: 9 + (12 x Player Count) bytes
+
+5.8 Admin System Payloads
+
+5.8.1 CLIENT_ADMIN_AUTH (0x30)
+
+   Admin authentication request with hashed password.
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                          Client ID                            |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                                                               |
+      +                     Password Hash (64 bytes)                 +
+      |                             ...                               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                                                               |
+      +                       Username (32 bytes)                    +
+      |                             ...                               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   Field           | Size      | Description
+   ----------------|-----------|---------------------------------------
+   Client ID       | 4 bytes   | Client identifier
+   Password Hash   | 64 bytes  | Hexadecimal string of hashed password
+   Username        | 32 bytes  | Admin username (null-terminated)
+
+   Total Size: 100 bytes
+
+5.8.2 CLIENT_ADMIN_COMMAND (0x31)
+
+   Execute an admin command on the server.
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                           Admin ID                            |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                                                               |
+      +                       Command (128 bytes)                    +
+      |                             ...                               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   Field       | Size       | Description
+   ------------|------------|------------------------------------------
+   Admin ID    | 4 bytes    | Authenticated admin ID
+   Command     | 128 bytes  | Command string (null-terminated)
+
+   Total Size: 132 bytes
+
+   Available Commands:
+
+   Tier 1 - Basic Commands:
+   - help                     Show available commands
+   - list                     List connected players
+   - kick <player_id> [reason] Kick a player from the server
+   - info                     Display server statistics
+
+   Tier 2 - Game Control Commands:
+   - pause                    Pause all active game sessions
+   - resume                   Resume all paused game sessions
+   - clearenemies [session_id] Clear enemies from sessions
+
+5.8.3 SERVER_ADMIN_AUTH_RESULT (0xF0)
+
+   Result of admin authentication attempt.
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |   Success     |                                               |
+      +-+-+-+-+-+-+-+-+                                               +
+      |                         Admin Level                           |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                                                               |
+      +                   Failure Reason (128 bytes)                 +
+      |                             ...                               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   Field           | Size      | Description
+   ----------------|-----------|---------------------------------------
+   Success         | 1 byte    | 1 = authenticated, 0 = failed
+   Admin Level     | 4 bytes   | Admin privilege level (if success=1)
+   Failure Reason  | 128 bytes | Error message (if success=0)
+
+   Total Size: 133 bytes
+
+5.8.4 SERVER_ADMIN_COMMAND_RESULT (0xF1)
+
+   Result of admin command execution.
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |   Success     |                                               |
+      +-+-+-+-+-+-+-+-+                                               +
+      |                                                               |
+      +                      Message (256 bytes)                     +
+      |                             ...                               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   Field    | Size       | Description
+   ---------|------------|------------------------------------------
+   Success  | 1 byte     | 1 = success, 0 = failed
+   Message  | 256 bytes  | Result or error message (null-terminated)
+
+   Total Size: 257 bytes
+
+5.8.5 SERVER_ADMIN_NOTIFICATION (0xF2)
+
+   Server-wide notification broadcast from admin.
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                                                               |
+      +                      Message (256 bytes)                     +
+      |                             ...                               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   Field    | Size       | Description
+   ---------|------------|------------------------------------------
+   Message  | 256 bytes  | Notification message (null-terminated)
+
+   Total Size: 256 bytes
+
+5.8.6 SERVER_KICK_NOTIFICATION (0xF3)
+
+   Notification sent to a player who is being kicked.
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                                                               |
+      +                       Reason (128 bytes)                     +
+      |                             ...                               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   Field   | Size       | Description
+   --------|------------|-------------------------------------------
+   Reason  | 128 bytes  | Kick reason message (null-terminated)
+
+   Total Size: 128 bytes
 
 6. Communication Patterns
 

--- a/src/engine/include/plugin_manager/INetworkPlugin.hpp
+++ b/src/engine/include/plugin_manager/INetworkPlugin.hpp
@@ -91,6 +91,13 @@ public:
      */
     virtual bool is_server_running() const = 0;
 
+    /**
+     * @brief Disconnect a specific client from the server
+     * @param client_id The TCP client ID to disconnect
+     * @note This will close both TCP and UDP connections for the client
+     */
+    virtual void disconnect_client(ClientId client_id) = 0;
+
     // ============== Client Operations ==============
 
     /**

--- a/src/engine/include/plugins/network/asio/AsioNetworkPlugin.hpp
+++ b/src/engine/include/plugins/network/asio/AsioNetworkPlugin.hpp
@@ -49,6 +49,7 @@ public:
     bool start_server(uint16_t tcp_port, uint16_t udp_port, bool listen_on_all_interfaces);
     void stop_server() override;
     bool is_server_running() const override;
+    void disconnect_client(ClientId client_id) override;
 
     // Client operations
     bool connect_tcp(const std::string& host, uint16_t port) override;

--- a/src/r-type/client/CMakeLists.txt
+++ b/src/r-type/client/CMakeLists.txt
@@ -14,6 +14,7 @@ set(RTYPE_CLIENT_SOURCES
     src/ui/UIButton.cpp
     src/ui/UITextField.cpp
     src/ui/UILabel.cpp
+    src/ui/ConsoleOverlay.cpp
     # Screen classes
     src/screens/MainMenuScreen.cpp
     src/screens/CreateRoomScreen.cpp

--- a/src/r-type/client/include/ClientGame.hpp
+++ b/src/r-type/client/include/ClientGame.hpp
@@ -21,6 +21,7 @@
 #include "systems/ClientPredictionSystem.hpp"
 #include "systems/InterpolationSystem.hpp"
 #include "DebugNetworkOverlay.hpp"
+#include "ui/ConsoleOverlay.hpp"
 
 namespace rtype::client {
 
@@ -83,7 +84,7 @@ private:
     std::unique_ptr<rtype::ParallaxBackgroundSystem> parallax_system_;
     std::unique_ptr<rtype::ChunkManagerSystem> chunk_manager_;
     float map_scroll_x_ = 0.0f;
-    std::string current_map_id_str_ = "nebula_outpost";  // Current map ID
+    std::string current_map_id_str_ = "nebula_outpost";
     float server_scroll_speed_ = 60.0f;
 
     // Network client
@@ -94,13 +95,18 @@ private:
     std::unique_ptr<rtype::client::InterpolationSystem> interpolation_system_;
     std::unique_ptr<rtype::client::DebugNetworkOverlay> debug_network_overlay_;
 
+    // Admin console overlay
+    std::unique_ptr<ConsoleOverlay> console_overlay_;
+    bool admin_authenticated_ = false;
+    std::string admin_password_;
+
     // Game state
     std::atomic<bool> running_;
     uint32_t client_tick_;
     Entity wave_tracker_;
-    float current_time_;  // Temps écoulé depuis démarrage (pour extrapolation)
-    uint16_t current_map_id_ = 1;  // Current map (1=Nebula, 2=Asteroid, 3=Bydo)
-    int last_known_score_ = 0;  // Last known score of local player (for game over screen)
+    float current_time_;
+    uint16_t current_map_id_ = 1;
+    int last_known_score_ = 0;
 
     // Background entities (legacy, kept for menu)
     Entity background1_;
@@ -116,8 +122,8 @@ private:
     void setup_registry();
     void setup_systems();
     void setup_background();
-    void setup_map_system();  // New map system setup
-    void load_map(const std::string& mapId);  // Load specific map by ID
+    void setup_map_system();
+    void load_map(const std::string& mapId);
     void setup_network_callbacks();
 
     // Map-specific theming
@@ -129,6 +135,9 @@ private:
 
     // Client-side prediction
     void apply_input_to_local_player(uint16_t input_flags);
+
+    // Admin console
+    void handle_console_command(const std::string& command);
 };
 
 }

--- a/src/r-type/client/include/NetworkClient.hpp
+++ b/src/r-type/client/include/NetworkClient.hpp
@@ -38,8 +38,6 @@ public:
 
     ~NetworkClient();
 
-    // ============== Connection ==============
-
     /**
      * @brief Connect to server via TCP
      * @param host Server hostname or IP
@@ -62,8 +60,6 @@ public:
      * @brief Check if UDP is connected
      */
     bool is_udp_connected() const;
-
-    // ============== Sending ==============
 
     /**
      * @brief Send connection request to server
@@ -147,14 +143,10 @@ public:
      */
     void send_input(uint16_t input_flags, uint32_t client_tick);
 
-    // ============== Update ==============
-
     /**
      * @brief Process incoming packets - call this every frame
      */
     void update();
-
-    // ============== Callbacks ==============
 
     /**
      * @brief Set callback for when connection is accepted
@@ -291,14 +283,38 @@ public:
      */
     void set_on_player_skin_updated(std::function<void(const protocol::ServerPlayerSkinUpdatedPayload&)> callback);
 
-    // ============== Getters ==============
+    /**
+     * @brief Send admin authentication request
+     * @param password Admin password (will be hashed client-side)
+     */
+    void send_admin_auth(const std::string& password);
+
+    /**
+     * @brief Send admin command
+     * @param command Command string to execute
+     */
+    void send_admin_command(const std::string& command);
+
+    /**
+     * @brief Set callback for admin auth result
+     * @param callback Function receiving success status and message
+     */
+    using AdminAuthCallback = std::function<void(bool success, const std::string& message)>;
+    void set_on_admin_auth_result(AdminAuthCallback callback);
+
+    /**
+     * @brief Set callback for admin command result
+     * @param callback Function receiving success status and message
+     */
+    using AdminCommandResultCallback = std::function<void(bool success, const std::string& message)>;
+    void set_on_admin_command_result(AdminCommandResultCallback callback);
 
     uint32_t get_player_id() const { return player_id_; }
     uint32_t get_session_id() const { return session_id_; }
     uint32_t get_lobby_id() const { return lobby_id_; }
     bool is_in_lobby() const { return in_lobby_; }
     bool is_in_game() const { return in_game_; }
-    uint32_t get_last_input_sequence() const { return input_sequence_number_ - 1; }  // Returns last sent sequence
+    uint32_t get_last_input_sequence() const { return input_sequence_number_ - 1; }
 
 private:
     void handle_packet(const engine::NetworkPacket& packet);
@@ -327,6 +343,10 @@ private:
     void handle_room_error(const std::vector<uint8_t>& payload);
     void handle_player_name_updated(const std::vector<uint8_t>& payload);
     void handle_player_skin_updated(const std::vector<uint8_t>& payload);
+    void handle_admin_auth_result(const std::vector<uint8_t>& payload);
+    void handle_admin_command_result(const std::vector<uint8_t>& payload);
+    void handle_admin_notification(const std::vector<uint8_t>& payload);
+    void handle_kick_notification(const std::vector<uint8_t>& payload);
 
     // UDP connection after game start
     void connect_udp(uint16_t udp_port);
@@ -386,6 +406,11 @@ private:
     std::function<void(const protocol::ServerRoomErrorPayload&)> on_room_error_;
     std::function<void(const protocol::ServerPlayerNameUpdatedPayload&)> on_player_name_updated_;
     std::function<void(const protocol::ServerPlayerSkinUpdatedPayload&)> on_player_skin_updated_;
+
+    // Admin callbacks
+    bool is_admin_authenticated_ = false;
+    AdminAuthCallback on_admin_auth_result_;
+    AdminCommandResultCallback on_admin_command_result_;
 };
 
 }

--- a/src/r-type/client/include/ui/ConsoleOverlay.hpp
+++ b/src/r-type/client/include/ui/ConsoleOverlay.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "ui/UITextField.hpp"
+#include "plugin_manager/IGraphicsPlugin.hpp"
+#include "plugin_manager/IInputPlugin.hpp"
+#include <vector>
+#include <deque>
+#include <string>
+#include <functional>
+#include <memory>
+
+namespace rtype::client {
+
+/**
+ * @brief In-game admin console overlay
+ *
+ * Provides UI for:
+ * - Text input for commands
+ * - Message history display
+ * - Command history (up/down arrows)
+ */
+class ConsoleOverlay {
+public:
+    ConsoleOverlay(float screen_width, float screen_height);
+
+    // Visibility
+    void toggle();
+    void set_visible(bool visible);
+    bool is_visible() const { return visible_; }
+
+    // Message display
+    void add_message(const std::string& message,
+                    engine::Color color = {255, 255, 255, 255});
+    void add_error(const std::string& error);
+    void add_success(const std::string& message);
+    void add_info(const std::string& info);
+
+    // Command callback
+    using CommandCallback = std::function<void(const std::string&)>;
+    void set_command_callback(CommandCallback callback) { on_command_ = callback; }
+
+    // Update and render
+    void update(engine::IGraphicsPlugin* graphics, engine::IInputPlugin* input);
+    void draw(engine::IGraphicsPlugin* graphics);
+
+private:
+    bool visible_;
+    float x_, y_, width_, height_;
+
+    // Message history
+    struct Message {
+        std::string text;
+        engine::Color color;
+    };
+    std::deque<Message> message_history_;
+    static constexpr size_t MAX_MESSAGES = 20;
+
+    // Input field
+    std::unique_ptr<rtype::UITextField> input_field_;
+
+    // Command history
+    std::deque<std::string> command_history_;
+    size_t command_history_index_;
+    static constexpr size_t MAX_COMMAND_HISTORY = 50;
+
+    // Callback
+    CommandCallback on_command_;
+
+    // Input handling
+    void execute_command();
+    void handle_history_navigation(engine::IInputPlugin* input);
+
+    // Key tracking for history navigation
+    bool was_up_pressed_ = false;
+    bool was_down_pressed_ = false;
+};
+
+}

--- a/src/r-type/client/src/ClientGame.cpp
+++ b/src/r-type/client/src/ClientGame.cpp
@@ -109,6 +109,29 @@ bool ClientGame::initialize(const std::string& host, uint16_t tcp_port, const st
     interpolation_system_ = std::make_unique<InterpolationSystem>();
     debug_network_overlay_ = std::make_unique<DebugNetworkOverlay>(false);
 
+    console_overlay_ = std::make_unique<ConsoleOverlay>(
+        static_cast<float>(screen_width_),
+        static_cast<float>(screen_height_)
+    );
+    console_overlay_->set_command_callback([this](const std::string& cmd) {
+        handle_console_command(cmd);
+    });
+    network_client_->set_on_admin_auth_result([this](bool success, const std::string& msg) {
+        if (success) {
+            admin_authenticated_ = true;
+            console_overlay_->add_success(msg);
+        } else {
+            admin_authenticated_ = false;
+            console_overlay_->add_error("Auth failed: " + msg);
+        }
+    });
+    network_client_->set_on_admin_command_result([this](bool success, const std::string& msg) {
+        if (success)
+            console_overlay_->add_success(msg);
+        else
+            console_overlay_->add_error(msg);
+    });
+
     // Initialize menu manager
     menu_manager_ = std::make_unique<MenuManager>(*network_client_, screen_width_, screen_height_);
     menu_manager_->initialize();
@@ -887,7 +910,13 @@ void ClientGame::run() {
             }
         }
 
-        // Toggle network debug overlay with F3 key
+        static bool tab_was_pressed = false;
+        bool tab_pressed = input_plugin_->is_key_pressed(engine::Key::Tab);
+        if (tab_pressed && !tab_was_pressed)
+            console_overlay_->toggle();
+        tab_was_pressed = tab_pressed;
+        if (console_overlay_->is_visible())
+            console_overlay_->update(graphics_plugin_, input_plugin_);
         if (input_handler_->is_network_debug_toggle_pressed()) {
             if (debug_network_overlay_) {
                 bool new_state = !debug_network_overlay_->is_enabled();
@@ -1130,11 +1159,10 @@ void ClientGame::run() {
             debug_network_overlay_->render(*graphics_plugin_);
         }
 
-        // Render result screen button (if on victory/defeat screen)
-        if (in_result) {
+        if (in_result)
             screen_manager_->draw_result_screen(graphics_plugin_);
-        }
-
+        if (console_overlay_)
+            console_overlay_->draw(graphics_plugin_);
         graphics_plugin_->display();
         input_plugin_->update();  // Update at END of frame for proper just_pressed detection
     }
@@ -1177,6 +1205,33 @@ void ClientGame::apply_input_to_local_player(uint16_t input_flags) {
     if (input_flags & protocol::INPUT_DOWN)  dir_y += 1.0f;
 
     registry_->get_event_bus().publish(ecs::PlayerMoveEvent{player, dir_x, dir_y});
+}
+
+void ClientGame::handle_console_command(const std::string& command) {
+    if (command == "clear") {
+        console_overlay_->add_info("Console cleared");
+        return;
+    }
+
+    if (command == "auth" || command.substr(0, 5) == "auth ") {
+        std::string password;
+        if (command.length() > 5)
+            password = command.substr(5);
+        else if (!admin_password_.empty())
+            password = admin_password_;
+        else {
+            console_overlay_->add_error("Usage: auth <password>");
+            return;
+        }
+        network_client_->send_admin_auth(password);
+        console_overlay_->add_info("Authenticating...");
+        return;
+    }
+    if (!admin_authenticated_) {
+        console_overlay_->add_error("Not authenticated. Use: auth <password>");
+        return;
+    }
+    network_client_->send_admin_command(command);
 }
 
 }

--- a/src/r-type/client/src/ui/ConsoleOverlay.cpp
+++ b/src/r-type/client/src/ui/ConsoleOverlay.cpp
@@ -1,0 +1,148 @@
+#include "ui/ConsoleOverlay.hpp"
+#include <iostream>
+
+namespace rtype::client {
+
+ConsoleOverlay::ConsoleOverlay(float screen_width, float screen_height)
+    : visible_(false)
+    , x_(10.0f)
+    , y_(10.0f)
+    , width_(screen_width - 20.0f)
+    , height_(400.0f)
+    , command_history_index_(0)
+{
+    input_field_ = std::make_unique<rtype::UITextField>(
+        x_ + 10.0f,
+        y_ + height_ - 45.0f,
+        width_ - 20.0f,
+        35.0f,
+        "> Enter admin command..."
+    );
+    input_field_->set_max_length(128);
+}
+
+void ConsoleOverlay::toggle()
+{
+    visible_ = !visible_;
+    if (visible_) {
+        input_field_->set_focused(true);
+        add_info("Console opened. Type 'help' for commands.");
+    } else
+        input_field_->set_focused(false);
+}
+
+void ConsoleOverlay::set_visible(bool visible)
+{
+    visible_ = visible;
+    input_field_->set_focused(visible);
+}
+
+void ConsoleOverlay::add_message(const std::string& message, engine::Color color)
+{
+    message_history_.push_back({message, color});
+    if (message_history_.size() > MAX_MESSAGES)
+        message_history_.pop_front();
+}
+
+void ConsoleOverlay::add_error(const std::string& error)
+{
+    add_message(error, {255, 60, 60, 255});  // Red
+}
+
+void ConsoleOverlay::add_success(const std::string& message)
+{
+    add_message(message, {60, 255, 60, 255});  // Green
+}
+
+void ConsoleOverlay::add_info(const std::string& info)
+{
+    add_message(info, {100, 200, 255, 255});  // Cyan
+}
+
+void ConsoleOverlay::update(engine::IGraphicsPlugin* graphics, engine::IInputPlugin* input)
+{
+    if (!visible_)
+        return;
+    input_field_->update(graphics, input);
+
+    if (input->is_key_just_pressed(engine::Key::Enter)) {
+        std::string command = input_field_->get_text();
+        if (!command.empty())
+            execute_command();
+    }
+    if (input->is_key_just_pressed(engine::Key::Escape)) {
+        toggle();
+        return;
+    }
+    handle_history_navigation(input);
+}
+
+void ConsoleOverlay::draw(engine::IGraphicsPlugin* graphics)
+{
+    if (!visible_)
+        return;
+
+    graphics->draw_rectangle(engine::Rectangle{x_, y_, width_, height_}, {10, 10, 20, 240});
+    graphics->draw_rectangle_outline(engine::Rectangle{x_, y_, width_, height_}, {100, 150, 255, 255}, 3);
+    graphics->draw_rectangle(engine::Rectangle{x_, y_, width_, 30.0f}, {20, 40, 80, 255});
+    graphics->draw_text("ADMIN CONSOLE (Tab to close)",
+                       engine::Vector2f{x_ + 10.0f, y_ + 7.0f},
+                       {200, 220, 255, 255},
+                       engine::INVALID_HANDLE,
+                       16);
+    float input_area_y = y_ + height_ - 55.0f;
+    graphics->draw_rectangle(engine::Rectangle{x_ + 5.0f, input_area_y, width_ - 10.0f, 2.0f}, {100, 150, 255, 180});
+    float line_height = 18.0f;
+    float line_y = input_area_y - 10.0f;
+    for (auto it = message_history_.rbegin();
+         it != message_history_.rend() && line_y > (y_ + 35.0f);
+         ++it) {
+        graphics->draw_text(it->text,
+                           engine::Vector2f{x_ + 15.0f, line_y},
+                           it->color,
+                           engine::INVALID_HANDLE,
+                           14);
+        line_y -= line_height;
+    }
+    input_field_->draw(graphics);
+}
+
+void ConsoleOverlay::execute_command()
+{
+    std::string command = input_field_->get_text();
+
+    add_message("> " + command, {255, 255, 100, 255});
+    command_history_.push_front(command);
+    if (command_history_.size() > MAX_COMMAND_HISTORY)
+        command_history_.pop_back();
+    command_history_index_ = 0;
+    if (on_command_)
+        on_command_(command);
+    input_field_->set_text("");
+}
+
+void ConsoleOverlay::handle_history_navigation(engine::IInputPlugin* input)
+{
+    bool up_pressed = input->is_key_pressed(engine::Key::Up);
+
+    if (up_pressed && !was_up_pressed_) {
+        if (command_history_index_ < command_history_.size()) {
+            input_field_->set_text(command_history_[command_history_index_]);
+            command_history_index_++;
+        }
+    }
+    was_up_pressed_ = up_pressed;
+    bool down_pressed = input->is_key_pressed(engine::Key::Down);
+    if (down_pressed && !was_down_pressed_) {
+        if (command_history_index_ > 0) {
+            command_history_index_--;
+            if (command_history_index_ > 0)
+                input_field_->set_text(command_history_[command_history_index_ - 1]);
+            else
+                input_field_->set_text("");
+        }
+    }
+    was_down_pressed_ = down_pressed;
+}
+
+}

--- a/src/r-type/client/src/ui/UITextField.cpp
+++ b/src/r-type/client/src/ui/UITextField.cpp
@@ -181,6 +181,24 @@ void UITextField::handle_text_input(engine::IInputPlugin* input) {
             key_repeat_timer_ -= 0.016f;
             return;
         }
+
+        if (input->is_key_pressed(engine::Key::Num8)) {
+            if (last_key_ != engine::Key::Num8 || key_repeat_timer_ <= 0.0f) {
+                bool shift = input->is_key_pressed(engine::Key::LShift) ||
+                            input->is_key_pressed(engine::Key::RShift);
+                if (shift) {
+                    text_ += '_';
+                    if (on_change_) {
+                        on_change_(text_);
+                    }
+                    last_key_ = engine::Key::Num8;
+                    key_repeat_timer_ = KEY_REPEAT_DELAY;
+                }
+            }
+            key_repeat_timer_ -= 0.016f;
+            if (input->is_key_pressed(engine::Key::LShift) || input->is_key_pressed(engine::Key::RShift))
+                return;
+        }
     }
 
     // Reset if no key is pressed

--- a/src/r-type/server/CMakeLists.txt
+++ b/src/r-type/server/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(r-type_server
     src/main.cpp
     src/Server.cpp
+    src/AdminManager.cpp
     src/NetworkHandler.cpp
     src/PacketSender.cpp
     src/GameSessionManager.cpp

--- a/src/r-type/server/include/AdminManager.hpp
+++ b/src/r-type/server/include/AdminManager.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include <functional>
+#include <cstdint>
+
+namespace rtype::server {
+
+class Server;  // Forward declaration
+
+/**
+ * @brief Admin command handler
+ * Manages admin authentication and command execution
+ */
+class AdminManager {
+public:
+    explicit AdminManager(Server* server, const std::string& password_hash);
+
+    bool verify_password(const std::string& password_hash) const;
+
+    struct CommandResult {
+        bool success;
+        std::string message;
+    };
+
+    CommandResult execute_command(uint32_t admin_id, const std::string& command);
+
+private:
+    Server* server_;
+    std::string admin_password_hash_;
+
+    using CommandHandler = std::function<CommandResult(const std::vector<std::string>&)>;
+    std::unordered_map<std::string, CommandHandler> commands_;
+
+    void register_commands();
+    std::vector<std::string> parse_command(const std::string& command);
+
+    CommandResult cmd_help(const std::vector<std::string>& args);
+    CommandResult cmd_list(const std::vector<std::string>& args);
+    CommandResult cmd_kick(const std::vector<std::string>& args);
+    CommandResult cmd_info(const std::vector<std::string>& args);
+
+    // Tier 2 - Game control commands
+    CommandResult cmd_pause(const std::vector<std::string>& args);
+    CommandResult cmd_resume(const std::vector<std::string>& args);
+    CommandResult cmd_clear_enemies(const std::vector<std::string>& args);
+};
+
+}

--- a/src/r-type/server/include/GameSession.hpp
+++ b/src/r-type/server/include/GameSession.hpp
@@ -96,6 +96,11 @@ public:
      */
     void resync_client(uint32_t player_id, uint32_t tcp_client_id);
 
+    // Admin commands
+    void pause();
+    void resume();
+    void clear_enemies();
+
 private:
     void on_wave_started(const Wave& wave) override;
     void on_wave_completed(const Wave& wave) override;
@@ -124,6 +129,7 @@ private:
     protocol::Difficulty difficulty_;
     uint16_t map_id_;
     std::atomic<bool> is_active_;
+    bool is_paused_ = false;
 
     Registry registry_;
     std::unordered_map<uint32_t, GamePlayer> players_;

--- a/src/r-type/server/include/PlayerInfo.hpp
+++ b/src/r-type/server/include/PlayerInfo.hpp
@@ -26,6 +26,10 @@ struct PlayerInfo {
     bool in_game;
     uint32_t session_id;
 
+    // Admin status
+    bool is_admin;
+    std::string admin_username;
+
     PlayerInfo()
         : client_id(0)
         , udp_client_id(0)
@@ -35,7 +39,9 @@ struct PlayerInfo {
         , in_lobby(false)
         , lobby_id(0)
         , in_game(false)
-        , session_id(0) {}
+        , session_id(0)
+        , is_admin(false)
+        , admin_username("") {}
 
     PlayerInfo(uint32_t cid, uint32_t pid, const std::string& name)
         : client_id(cid)
@@ -47,7 +53,9 @@ struct PlayerInfo {
         , in_lobby(false)
         , lobby_id(0)
         , in_game(false)
-        , session_id(0) {}
+        , session_id(0)
+        , is_admin(false)
+        , admin_username("") {}
 
     bool has_udp_connection() const { return udp_client_id != 0; }
 };

--- a/src/r-type/server/include/interfaces/INetworkListener.hpp
+++ b/src/r-type/server/include/interfaces/INetworkListener.hpp
@@ -121,6 +121,20 @@ public:
      * @param payload Skin change data
      */
     virtual void on_client_set_player_skin(uint32_t client_id, const protocol::ClientSetPlayerSkinPayload& payload) = 0;
+
+    /**
+     * @brief Called when a client sends admin authentication
+     * @param client_id TCP client ID
+     * @param payload Admin auth data (password hash, username)
+     */
+    virtual void on_admin_auth(uint32_t client_id, const protocol::ClientAdminAuthPayload& payload) = 0;
+
+    /**
+     * @brief Called when a client sends admin command
+     * @param client_id TCP client ID
+     * @param payload Admin command data (command string)
+     */
+    virtual void on_admin_command(uint32_t client_id, const protocol::ClientAdminCommandPayload& payload) = 0;
 };
 
 }

--- a/src/r-type/server/src/AdminManager.cpp
+++ b/src/r-type/server/src/AdminManager.cpp
@@ -1,0 +1,175 @@
+#include "AdminManager.hpp"
+#include "Server.hpp"
+#include <sstream>
+#include <algorithm>
+#include <iostream>
+
+namespace rtype::server {
+
+AdminManager::AdminManager(Server* server, const std::string& password_hash)
+    : server_(server)
+    , admin_password_hash_(password_hash)
+{
+    register_commands();
+}
+
+bool AdminManager::verify_password(const std::string& password_hash) const
+{
+    return password_hash == admin_password_hash_;
+}
+
+void AdminManager::register_commands()
+{
+    commands_["help"] = [this](const auto& args) { return cmd_help(args); };
+    commands_["list"] = [this](const auto& args) { return cmd_list(args); };
+    commands_["kick"] = [this](const auto& args) { return cmd_kick(args); };
+    commands_["info"] = [this](const auto& args) { return cmd_info(args); };
+    commands_["pause"] = [this](const auto& args) { return cmd_pause(args); };
+    commands_["resume"] = [this](const auto& args) { return cmd_resume(args); };
+    commands_["clearenemies"] = [this](const auto& args) { return cmd_clear_enemies(args); };
+}
+
+std::vector<std::string> AdminManager::parse_command(const std::string& command)
+{
+    std::vector<std::string> tokens;
+    std::istringstream iss(command);
+    std::string token;
+
+    while (iss >> token) {
+        tokens.push_back(token);
+    }
+
+    return tokens;
+}
+
+AdminManager::CommandResult AdminManager::execute_command(uint32_t admin_id,
+                                                          const std::string& command)
+{
+    auto tokens = parse_command(command);
+
+    if (tokens.empty())
+        return {false, "Empty command"};
+    std::string cmd = tokens[0];
+    if (!cmd.empty() && cmd[0] == '/')
+        cmd = cmd.substr(1);
+    std::transform(cmd.begin(), cmd.end(), cmd.begin(), ::tolower);
+    auto it = commands_.find(cmd);
+    if (it == commands_.end())
+        return {false, "Unknown command: " + cmd + ". Type 'help' for available commands."};
+    std::vector<std::string> args(tokens.begin() + 1, tokens.end());
+    return it->second(args);
+}
+
+AdminManager::CommandResult AdminManager::cmd_help(const std::vector<std::string>& args)
+{
+    std::ostringstream oss;
+    oss << "Available admin commands:\n"
+        << "Tier 1 - Basic:\n"
+        << "  help                 - Show this help\n"
+        << "  list                 - List connected players\n"
+        << "  kick <player_id>     - Kick a player\n"
+        << "  info                 - Server statistics\n"
+        << "\n"
+        << "Tier 2 - Game Control:\n"
+        << "  pause                - Pause all game sessions\n"
+        << "  resume               - Resume all game sessions\n"
+        << "  clearenemies [sid]   - Clear enemies (session_id optional)";
+    return {true, oss.str()};
+}
+
+AdminManager::CommandResult AdminManager::cmd_list(const std::vector<std::string>& args)
+{
+    auto players = server_->get_connected_players();
+
+    if (players.empty())
+        return {true, "No players connected"};
+    std::ostringstream oss;
+    oss << "Connected players (" << players.size() << "):\n";
+    for (const auto& player : players) {
+        oss << "  [ID: " << player.player_id << "] " << player.player_name;
+        if (player.in_game)
+            oss << " (in game - session " << player.session_id << ")";
+        oss << "\n";
+    }
+    return {true, oss.str()};
+}
+
+AdminManager::CommandResult AdminManager::cmd_kick(const std::vector<std::string>& args)
+{
+    if (args.empty())
+        return {false, "Usage: kick <player_id>"};
+    uint32_t player_id;
+
+    try {
+        player_id = std::stoul(args[0]);
+    } catch (...) {
+        return {false, "Invalid player ID: " + args[0]};
+    }
+    std::string reason = "Kicked by admin";
+    if (args.size() > 1) {
+        reason = "";
+        for (size_t i = 1; i < args.size(); ++i) {
+            reason += args[i];
+            if (i < args.size() - 1) reason += " ";
+        }
+    }
+    bool success = server_->kick_player(player_id, reason);
+    if (success)
+        return {true, "Player " + std::to_string(player_id) + " kicked"};
+    else
+        return {false, "Player " + std::to_string(player_id) + " not found"};
+}
+
+AdminManager::CommandResult AdminManager::cmd_info(const std::vector<std::string>& args)
+{
+    auto stats = server_->get_server_stats();
+
+    std::ostringstream oss;
+    oss << "Server Statistics:\n"
+        << "  Uptime: " << stats.uptime_seconds << "s\n"
+        << "  Connected Players: " << stats.connected_players << "\n"
+        << "  Active Sessions: " << stats.active_sessions << "\n"
+        << "  Total Connections: " << stats.total_connections;
+    return {true, oss.str()};
+}
+
+AdminManager::CommandResult AdminManager::cmd_pause(const std::vector<std::string>& args)
+{
+    uint32_t paused_count = server_->pause_all_sessions();
+
+    if (paused_count == 0)
+        return {false, "No active game sessions to pause"};
+    return {true, "Paused " + std::to_string(paused_count) + " game session(s)"};
+}
+
+AdminManager::CommandResult AdminManager::cmd_resume(const std::vector<std::string>& args)
+{
+    uint32_t resumed_count = server_->resume_all_sessions();
+
+    if (resumed_count == 0)
+        return {false, "No paused game sessions to resume"};
+    return {true, "Resumed " + std::to_string(resumed_count) + " game session(s)"};
+}
+
+AdminManager::CommandResult AdminManager::cmd_clear_enemies(const std::vector<std::string>& args)
+{
+    if (!args.empty()) {
+        uint32_t session_id;
+        try {
+            session_id = std::stoul(args[0]);
+        } catch (...) {
+            return {false, "Invalid session_id: " + args[0]};
+        }
+        bool success = server_->clear_enemies_in_session(session_id);
+        if (success)
+            return {true, "Cleared enemies from session " + std::to_string(session_id)};
+        else
+            return {false, "Session " + std::to_string(session_id) + " not found"};
+    }
+    uint32_t cleared_count = server_->clear_enemies_all_sessions();
+    if (cleared_count == 0)
+        return {false, "No active game sessions"};
+    return {true, "Cleared enemies from " + std::to_string(cleared_count) + " session(s)"};
+}
+
+}

--- a/src/r-type/server/src/GameSession.cpp
+++ b/src/r-type/server/src/GameSession.cpp
@@ -238,12 +238,18 @@ void GameSession::update(float delta_time)
 {
     if (!is_active_)
         return;
+
+    if (is_paused_) {
+        if (network_system_)
+            network_system_->update(registry_, delta_time);
+        return;
+    }
+
     tick_count_++;
     current_scroll_ += scroll_speed_ * delta_time;
-    
-    // Spawn walls from map tiles as they come into view
+
     spawn_walls_in_view();
-    
+
     wave_manager_.update(delta_time, current_scroll_);
     registry_.get_system<BonusSystem>().update(registry_, delta_time);
     registry_.get_system<BonusWeaponSystem>().update(registry_, delta_time);
@@ -705,6 +711,30 @@ void GameSession::spawn_walls_in_view()
         segment_world_x += segment_width;
         next_segment_to_spawn_++;
     }
+}
+
+void GameSession::pause()
+{
+    is_paused_ = true;
+    std::cout << "[GameSession " << session_id_ << "] Paused\n";
+}
+
+void GameSession::resume()
+{
+    is_paused_ = false;
+    std::cout << "[GameSession " << session_id_ << "] Resumed\n";
+}
+
+void GameSession::clear_enemies()
+{
+    auto& enemy_components = registry_.get_components<Enemy>();
+    size_t count = enemy_components.size();
+
+    for (size_t i = 0; i < count; ++i) {
+        Entity enemy_entity = enemy_components.get_entity_at(i);
+        registry_.add_component(enemy_entity, ToDestroy{});
+    }
+    std::cout << "[GameSession " << session_id_ << "] Cleared " << count << " enemies\n";
 }
 
 }

--- a/src/r-type/server/src/NetworkHandler.cpp
+++ b/src/r-type/server/src/NetworkHandler.cpp
@@ -190,6 +190,26 @@ void NetworkHandler::handle_tcp_packet(uint32_t client_id, protocol::PacketType 
             listener_->on_client_set_player_skin(client_id, data);
             break;
         }
+        case protocol::PacketType::CLIENT_ADMIN_AUTH: {
+            if (payload.size() != sizeof(protocol::ClientAdminAuthPayload)) {
+                std::cerr << "[NetworkHandler] Invalid CLIENT_ADMIN_AUTH payload size\n";
+                return;
+            }
+            protocol::ClientAdminAuthPayload data;
+            Memory::copy_to_struct(data, payload.data());
+            listener_->on_admin_auth(client_id, data);
+            break;
+        }
+        case protocol::PacketType::CLIENT_ADMIN_COMMAND: {
+            if (payload.size() != sizeof(protocol::ClientAdminCommandPayload)) {
+                std::cerr << "[NetworkHandler] Invalid CLIENT_ADMIN_COMMAND payload size\n";
+                return;
+            }
+            protocol::ClientAdminCommandPayload data;
+            Memory::copy_to_struct(data, payload.data());
+            listener_->on_admin_command(client_id, data);
+            break;
+        }
         default:
             std::cerr << "[NetworkHandler] Unexpected TCP packet type: 0x" << std::hex
                       << static_cast<int>(type) << std::dec << "\n";

--- a/src/r-type/shared/protocol/PacketTypes.hpp
+++ b/src/r-type/shared/protocol/PacketTypes.hpp
@@ -13,12 +13,13 @@ namespace rtype::protocol {
  * - 0x05-0x09: Lobby & Matchmaking (Client → Server)
  * - 0x10-0x1F: Player Input (Client → Server)
  * - 0x20-0x29: Room Management (Client → Server)
- * - 0x30-0x3F: Reserved for future client-to-server use
+ * - 0x30-0x3F: Admin Commands (Client → Server)
  * - 0x81-0x8A: Connection & Lobby (Server → Client)
  * - 0x90-0x9F: Room Management (Server → Client)
  * - 0xA0-0xAF: World State (Server → Client)
  * - 0xB0-0xBF: Entity Events (Server → Client)
  * - 0xC0-0xCF: Game Mechanics (Server → Client)
+ * - 0xD0-0xDF: Admin Responses (Server → Client)
  * - 0xF0-0xFF: System & Chat (Server → Client)
  */
 enum class PacketType : uint8_t {
@@ -44,6 +45,10 @@ enum class PacketType : uint8_t {
     CLIENT_START_GAME = 0x24,
     CLIENT_SET_PLAYER_NAME = 0x25,  // Change player name in lobby
     CLIENT_SET_PLAYER_SKIN = 0x26,  // Change player skin in lobby
+
+    // Admin Commands (0x30-0x3F)
+    CLIENT_ADMIN_AUTH = 0x30,           // Admin authentication request
+    CLIENT_ADMIN_COMMAND = 0x31,        // Admin command execution (kick, list, etc.)
 
     // ========== Server → Client ==========
     // Connection & Lobby (0x81-0x8A)
@@ -85,6 +90,12 @@ enum class PacketType : uint8_t {
     SERVER_WAVE_COMPLETE = 0xC3,
     SERVER_PLAYER_RESPAWN = 0xC5,
     SERVER_GAME_OVER = 0xC6,
+
+    // Admin Responses (0xD0-0xDF)
+    SERVER_ADMIN_AUTH_RESULT = 0xD0,    // Admin authentication result
+    SERVER_ADMIN_COMMAND_RESULT = 0xD1, // Admin command execution result
+    SERVER_ADMIN_NOTIFICATION = 0xD2,   // Admin notifications (player events, etc.)
+    SERVER_KICK_NOTIFICATION = 0xD3,    // Kick notification sent before disconnect
 };
 
 /**
@@ -404,10 +415,22 @@ inline std::string packet_type_to_string(PacketType type) {
         return "CLIENT_SET_PLAYER_NAME";
     case PacketType::CLIENT_SET_PLAYER_SKIN:
         return "CLIENT_SET_PLAYER_SKIN";
+    case PacketType::CLIENT_ADMIN_AUTH:
+        return "CLIENT_ADMIN_AUTH";
+    case PacketType::CLIENT_ADMIN_COMMAND:
+        return "CLIENT_ADMIN_COMMAND";
     case PacketType::SERVER_PLAYER_NAME_UPDATED:
         return "SERVER_PLAYER_NAME_UPDATED";
     case PacketType::SERVER_PLAYER_SKIN_UPDATED:
         return "SERVER_PLAYER_SKIN_UPDATED";
+    case PacketType::SERVER_ADMIN_AUTH_RESULT:
+        return "SERVER_ADMIN_AUTH_RESULT";
+    case PacketType::SERVER_ADMIN_COMMAND_RESULT:
+        return "SERVER_ADMIN_COMMAND_RESULT";
+    case PacketType::SERVER_ADMIN_NOTIFICATION:
+        return "SERVER_ADMIN_NOTIFICATION";
+    case PacketType::SERVER_KICK_NOTIFICATION:
+        return "SERVER_KICK_NOTIFICATION";
     default:
         return "UNKNOWN";
     }

--- a/src/r-type/shared/protocol/Payloads.hpp
+++ b/src/r-type/shared/protocol/Payloads.hpp
@@ -924,4 +924,158 @@ PACK_END
 
 static_assert(sizeof(ServerPlayerSkinUpdatedPayload) == 9, "ServerPlayerSkinUpdatedPayload must be 9 bytes");
 
+/**
+ * @brief CLIENT_ADMIN_AUTH payload (0x30)
+ * Client sends password hash to authenticate as admin
+ * Total size: 96 bytes
+ */
+PACK_START
+struct PACKED ClientAdminAuthPayload {
+    uint32_t client_id;              // 4 bytes - Network byte order
+    char password_hash[64];          // 64 bytes - SHA256 hex string
+    char username[28];               // 28 bytes - Admin username (display)
+
+    ClientAdminAuthPayload() : client_id(0) {
+        std::memset(password_hash, 0, sizeof(password_hash));
+        std::memset(username, 0, sizeof(username));
+    }
+
+    void set_password_hash(const std::string& hash) {
+        std::memset(password_hash, 0, sizeof(password_hash));
+        std::strncpy(password_hash, hash.c_str(), sizeof(password_hash) - 1);
+    }
+
+    void set_username(const std::string& name) {
+        std::memset(username, 0, sizeof(username));
+        std::strncpy(username, name.c_str(), sizeof(username) - 1);
+    }
+};
+PACK_END
+
+static_assert(sizeof(ClientAdminAuthPayload) == 96, "ClientAdminAuthPayload must be 96 bytes");
+
+/**
+ * @brief CLIENT_ADMIN_COMMAND payload (0x31)
+ * Client sends admin command to execute
+ * Total size: 140 bytes
+ */
+PACK_START
+struct PACKED ClientAdminCommandPayload {
+    uint32_t admin_id;               // 4 bytes - Admin player ID
+    uint8_t command_length;          // 1 byte - Length of command string
+    char command[135];               // 135 bytes - Command string
+
+    ClientAdminCommandPayload() : admin_id(0), command_length(0) {
+        std::memset(command, 0, sizeof(command));
+    }
+
+    void set_command(const std::string& cmd) {
+        command_length = std::min(static_cast<uint8_t>(cmd.size()),
+                                 static_cast<uint8_t>(sizeof(command) - 1));
+        std::memset(command, 0, sizeof(command));
+        std::strncpy(command, cmd.c_str(), command_length);
+    }
+
+    std::string get_command() const {
+        return std::string(command,
+                          std::min(static_cast<size_t>(command_length),
+                                  sizeof(command)));
+    }
+};
+PACK_END
+
+static_assert(sizeof(ClientAdminCommandPayload) == 140, "ClientAdminCommandPayload must be 140 bytes");
+
+/**
+ * @brief SERVER_ADMIN_AUTH_RESULT payload (0xD0)
+ * Server responds with authentication result
+ * Total size: 69 bytes
+ */
+PACK_START
+struct PACKED ServerAdminAuthResultPayload {
+    uint8_t success;                 // 1 byte - 0=failed, 1=success
+    uint32_t admin_level;            // 4 bytes - 0=none, 1=admin (future: roles)
+    char failure_reason[64];         // 64 bytes - Error message if failed
+
+    ServerAdminAuthResultPayload() : success(0), admin_level(0) {
+        std::memset(failure_reason, 0, sizeof(failure_reason));
+    }
+
+    void set_failure_reason(const std::string& reason) {
+        std::memset(failure_reason, 0, sizeof(failure_reason));
+        std::strncpy(failure_reason, reason.c_str(), sizeof(failure_reason) - 1);
+    }
+};
+PACK_END
+
+static_assert(sizeof(ServerAdminAuthResultPayload) == 69, "ServerAdminAuthResultPayload must be 69 bytes");
+
+/**
+ * @brief SERVER_ADMIN_COMMAND_RESULT payload (0xD1)
+ * Server responds with command execution result
+ * Total size: 257 bytes
+ */
+PACK_START
+struct PACKED ServerAdminCommandResultPayload {
+    uint8_t success;                 // 1 byte - 0=failed, 1=success
+    char message[256];               // 256 bytes - Result message or error
+
+    ServerAdminCommandResultPayload() : success(0) {
+        std::memset(message, 0, sizeof(message));
+    }
+
+    void set_message(const std::string& msg) {
+        std::memset(message, 0, sizeof(message));
+        std::strncpy(message, msg.c_str(), sizeof(message) - 1);
+    }
+};
+PACK_END
+
+static_assert(sizeof(ServerAdminCommandResultPayload) == 257, "ServerAdminCommandResultPayload must be 257 bytes");
+
+/**
+ * @brief SERVER_ADMIN_NOTIFICATION payload (0xD2)
+ * Server sends admin notifications (player events, etc.)
+ * Total size: 128 bytes
+ */
+PACK_START
+struct PACKED ServerAdminNotificationPayload {
+    uint8_t notification_type;       // 1 byte - Type of notification
+    char message[127];               // 127 bytes - Notification text
+
+    ServerAdminNotificationPayload() : notification_type(0) {
+        std::memset(message, 0, sizeof(message));
+    }
+
+    void set_message(const std::string& msg) {
+        std::memset(message, 0, sizeof(message));
+        std::strncpy(message, msg.c_str(), sizeof(message) - 1);
+    }
+};
+PACK_END
+
+static_assert(sizeof(ServerAdminNotificationPayload) == 128, "ServerAdminNotificationPayload must be 128 bytes");
+
+/**
+ * @brief SERVER_KICK_NOTIFICATION payload (0xD3)
+ * Server sends kick notification before disconnecting player
+ * Total size: 128 bytes
+ */
+PACK_START
+struct PACKED ServerKickNotificationPayload {
+    char reason[128];                // 128 bytes - Kick reason
+
+    ServerKickNotificationPayload() {
+        std::memset(reason, 0, sizeof(reason));
+    }
+
+    void set_reason(const std::string& msg) {
+        std::memset(reason, 0, sizeof(reason));
+        std::strncpy(reason, msg.c_str(), sizeof(reason) - 1);
+    }
+};
+PACK_END
+
+static_assert(sizeof(ServerKickNotificationPayload) == 128, "ServerKickNotificationPayload must be 128 bytes");
+
 }


### PR DESCRIPTION
Add comprehensive admin system with client-side console overlay and server-side game control commands for managing active game sessions.

Client Changes:
- Add ConsoleOverlay UI component with Tab key toggle (AZERTY compatible)
- Integrate admin authentication and command execution in NetworkClient
- Add admin packet handlers for auth results and command responses
- Support AZERTY keyboard underscore input (Shift+8) in UITextField

Server Changes:
- Implement Tier 2 game control commands (pause, resume, clearenemies)
- Add pause/resume functionality to GameSession with paused state tracking
- Add clear_enemies method to remove all enemy entities from sessions
- Support session-specific and global command execution
- Remove unused shutdown command and related infrastructure

Documentation:
- Update PROTOCOL.md with admin system payloads (section 5.7)
- Update PROTOCOL.txt with RFC-compliant admin packet documentation
- Document all available commands (Tier 1: help, list, kick, info)
- Document Tier 2 commands (pause, resume, clearenemies)