### PR TITLE
feat(client): add persistent config files and adjust minimap position

### DIFF
--- a/src/bagario/client/src/BagarioGame.cpp
+++ b/src/bagario/client/src/BagarioGame.cpp
@@ -21,6 +21,13 @@ bool BagarioGame::initialize(engine::IGraphicsPlugin* graphics, engine::IInputPl
         return false;
     }
 
+    // Load configuration files
+    game_state_.load_all_configs();
+    std::cout << "[BagarioGame] Loaded configuration files\n";
+
+    // Apply VSync setting from config
+    graphics_->set_vsync(game_state_.vsync);
+
     // Initialize network manager
     network_manager_ = std::make_unique<client::NetworkManager>();
     if (!network_manager_->initialize()) {

--- a/src/bagario/client/src/main.cpp
+++ b/src/bagario/client/src/main.cpp
@@ -62,7 +62,7 @@ int main(int argc, char* argv[]) {
         std::cerr << "[Bagario] Failed to create window!\n";
         return 1;
     }
-    graphics->set_vsync(false);  // VSync off by default for lower latency, can be enabled in Settings
+    // VSync is configured via settings.ini and loaded by BagarioGame
 
     // Load input plugin separately
     engine::IInputPlugin* input = nullptr;

--- a/src/bagario/client/src/screens/PlayingScreen.cpp
+++ b/src/bagario/client/src/screens/PlayingScreen.cpp
@@ -473,7 +473,7 @@ void PlayingScreen::draw_minimap(engine::IGraphicsPlugin* graphics) {
     // Minimap in bottom-right corner
     float mm_size = 150.0f;
     float mm_x = static_cast<float>(screen_width_) - mm_size - 10.0f;
-    float mm_y = static_cast<float>(screen_height_) - mm_size - 10.0f;
+    float mm_y = static_cast<float>(screen_height_) - mm_size - 50.0f;
 
     // Background
     engine::Color bg_color{20, 20, 30, 180};

--- a/src/bagario/client/src/screens/SettingsScreen.cpp
+++ b/src/bagario/client/src/screens/SettingsScreen.cpp
@@ -149,6 +149,8 @@ void SettingsScreen::rebuild_ui() {
     auto back_btn = std::make_unique<UIButton>(
         center_x - button_width / 2.0f, start_y + 500.0f, button_width, button_height, "Back");
     back_btn->set_on_click([this]() {
+        // Save settings before leaving
+        game_state_.save_settings();
         if (on_screen_change_) {
             on_screen_change_(GameScreen::WELCOME);
         }

--- a/src/bagario/client/src/screens/SkinScreen.cpp
+++ b/src/bagario/client/src/screens/SkinScreen.cpp
@@ -161,6 +161,8 @@ void SkinScreen::rebuild_ui() {
     back_button_ = std::make_unique<UIButton>(
         center_x - back_width / 2.0f, start_y + 730.0f, back_width, back_height, "Back");
     back_button_->set_on_click([this]() {
+        // Save user data (skin) before leaving
+        game_state_.save_user();
         if (on_screen_change_) {
             on_screen_change_(GameScreen::WELCOME);
         }

--- a/src/bagario/client/src/screens/WelcomeScreen.cpp
+++ b/src/bagario/client/src/screens/WelcomeScreen.cpp
@@ -72,6 +72,8 @@ void WelcomeScreen::initialize() {
         center_x - button_width / 2.0f, start_y + 400.0f, button_width, button_height, "PLAY");
     play_btn->set_on_click([this]() {
         std::cout << "[WelcomeScreen] Play clicked! Username: " << game_state_.username << "\n";
+        // Save user data (username, server_ip) before playing
+        game_state_.save_user();
         if (on_screen_change_) {
             on_screen_change_(GameScreen::PLAYING);
         }

--- a/src/bagario/shared/ConfigManager.hpp
+++ b/src/bagario/shared/ConfigManager.hpp
@@ -1,0 +1,160 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <fstream>
+#include <sstream>
+#include <filesystem>
+
+namespace bagario {
+
+/**
+ * @brief Simple INI file parser and writer
+ */
+class ConfigManager {
+public:
+    /**
+     * @brief Load an INI file
+     * @param filepath Path to the INI file
+     * @return true if loaded successfully
+     */
+    bool load(const std::string& filepath) {
+        filepath_ = filepath;
+        data_.clear();
+
+        std::ifstream file(filepath);
+        if (!file.is_open()) {
+            return false;
+        }
+
+        std::string current_section;
+        std::string line;
+
+        while (std::getline(file, line)) {
+            line = trim(line);
+
+            if (line.empty() || line[0] == ';' || line[0] == '#') {
+                continue;
+            }
+
+            if (line[0] == '[' && line.back() == ']') {
+                current_section = line.substr(1, line.size() - 2);
+                continue;
+            }
+
+            size_t eq_pos = line.find('=');
+            if (eq_pos != std::string::npos) {
+                std::string key = trim(line.substr(0, eq_pos));
+                std::string value = trim(line.substr(eq_pos + 1));
+
+                std::string full_key = current_section.empty() ? key : current_section + "." + key;
+                data_[full_key] = value;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @brief Save to an INI file
+     * @param filepath Path to save (uses loaded path if empty)
+     * @return true if saved successfully
+     */
+    bool save(const std::string& filepath = "") {
+        std::string path = filepath.empty() ? filepath_ : filepath;
+        if (path.empty()) {
+            return false;
+        }
+
+        std::filesystem::path dir = std::filesystem::path(path).parent_path();
+        if (!dir.empty() && !std::filesystem::exists(dir)) {
+            std::filesystem::create_directories(dir);
+        }
+
+        std::ofstream file(path);
+        if (!file.is_open()) {
+            return false;
+        }
+
+        std::unordered_map<std::string, std::vector<std::pair<std::string, std::string>>> sections;
+
+        for (const auto& [key, value] : data_) {
+            size_t dot_pos = key.find('.');
+            if (dot_pos != std::string::npos) {
+                std::string section = key.substr(0, dot_pos);
+                std::string name = key.substr(dot_pos + 1);
+                sections[section].emplace_back(name, value);
+            } else {
+                sections[""].emplace_back(key, value);
+            }
+        }
+
+        if (sections.count("") && !sections[""].empty()) {
+            for (const auto& [key, value] : sections[""]) {
+                file << key << " = " << value << "\n";
+            }
+            file << "\n";
+        }
+
+        for (const auto& [section, pairs] : sections) {
+            if (section.empty()) continue;
+            file << "[" << section << "]\n";
+            for (const auto& [key, value] : pairs) {
+                file << key << " = " << value << "\n";
+            }
+            file << "\n";
+        }
+
+        return true;
+    }
+
+    std::string get_string(const std::string& key, const std::string& default_value = "") const {
+        auto it = data_.find(key);
+        return it != data_.end() ? it->second : default_value;
+    }
+
+    int get_int(const std::string& key, int default_value = 0) const {
+        auto it = data_.find(key);
+        if (it != data_.end()) {
+            try {
+                return std::stoi(it->second);
+            } catch (...) {}
+        }
+        return default_value;
+    }
+
+    bool get_bool(const std::string& key, bool default_value = false) const {
+        auto it = data_.find(key);
+        if (it != data_.end()) {
+            std::string val = it->second;
+            for (char& c : val) c = std::tolower(c);
+            return val == "true" || val == "1" || val == "yes" || val == "on";
+        }
+        return default_value;
+    }
+
+    void set(const std::string& key, const std::string& value) {
+        data_[key] = value;
+    }
+
+    void set(const std::string& key, int value) {
+        data_[key] = std::to_string(value);
+    }
+
+    void set(const std::string& key, bool value) {
+        data_[key] = value ? "true" : "false";
+    }
+
+private:
+    std::string trim(const std::string& str) {
+        size_t start = str.find_first_not_of(" \t\r\n");
+        if (start == std::string::npos) return "";
+        size_t end = str.find_last_not_of(" \t\r\n");
+        return str.substr(start, end - start + 1);
+    }
+
+    std::string filepath_;
+    std::unordered_map<std::string, std::string> data_;
+};
+
+}  // namespace bagario

--- a/src/bagario/shared/LocalGameState.hpp
+++ b/src/bagario/shared/LocalGameState.hpp
@@ -5,8 +5,13 @@
 #include <cstdint>
 #include <fstream>
 #include "plugin_manager/IGraphicsPlugin.hpp"
+#include "ConfigManager.hpp"
 
 namespace bagario {
+
+// Config file paths (relative to executable)
+static constexpr const char* SETTINGS_CONFIG_PATH = "config/settings.ini";
+static constexpr const char* USER_CONFIG_PATH = "config/user.ini";
 
 /**
  * @brief Skin pattern types
@@ -212,6 +217,122 @@ struct LocalGameState {
     bool fullscreen = false;
     bool vsync = false;  // VSync disabled by default for lower input latency
     PlayerSkin skin;
+
+    /**
+     * @brief Load settings from settings.ini
+     * @return true if loaded successfully
+     */
+    bool load_settings() {
+        ConfigManager config;
+        if (!config.load(SETTINGS_CONFIG_PATH)) {
+            return false;
+        }
+
+        music_volume = config.get_int("Audio.music_volume", music_volume);
+        sfx_volume = config.get_int("Audio.sfx_volume", sfx_volume);
+        vsync = config.get_bool("Video.vsync", vsync);
+        fullscreen = config.get_bool("Video.fullscreen", fullscreen);
+
+        return true;
+    }
+
+    /**
+     * @brief Save settings to settings.ini
+     * @return true if saved successfully
+     */
+    bool save_settings() const {
+        ConfigManager config;
+
+        config.set("Audio.music_volume", music_volume);
+        config.set("Audio.sfx_volume", sfx_volume);
+        config.set("Video.vsync", vsync);
+        config.set("Video.fullscreen", fullscreen);
+
+        return config.save(SETTINGS_CONFIG_PATH);
+    }
+
+    /**
+     * @brief Load user data from user.ini
+     * @return true if loaded successfully
+     */
+    bool load_user() {
+        ConfigManager config;
+        if (!config.load(USER_CONFIG_PATH)) {
+            return false;
+        }
+
+        username = config.get_string("Profile.username", username);
+        server_ip = config.get_string("Network.server_ip", server_ip);
+
+        // Load skin settings
+        int pattern = config.get_int("Skin.pattern", static_cast<int>(skin.pattern));
+        if (pattern >= 0 && pattern <= static_cast<int>(SkinPattern::IMAGE)) {
+            skin.pattern = static_cast<SkinPattern>(pattern);
+        }
+
+        skin.primary.r = static_cast<uint8_t>(config.get_int("Skin.primary_r", skin.primary.r));
+        skin.primary.g = static_cast<uint8_t>(config.get_int("Skin.primary_g", skin.primary.g));
+        skin.primary.b = static_cast<uint8_t>(config.get_int("Skin.primary_b", skin.primary.b));
+
+        skin.secondary.r = static_cast<uint8_t>(config.get_int("Skin.secondary_r", skin.secondary.r));
+        skin.secondary.g = static_cast<uint8_t>(config.get_int("Skin.secondary_g", skin.secondary.g));
+        skin.secondary.b = static_cast<uint8_t>(config.get_int("Skin.secondary_b", skin.secondary.b));
+
+        skin.tertiary.r = static_cast<uint8_t>(config.get_int("Skin.tertiary_r", skin.tertiary.r));
+        skin.tertiary.g = static_cast<uint8_t>(config.get_int("Skin.tertiary_g", skin.tertiary.g));
+        skin.tertiary.b = static_cast<uint8_t>(config.get_int("Skin.tertiary_b", skin.tertiary.b));
+
+        std::string img_path = config.get_string("Skin.image_path", "");
+        if (!img_path.empty() && skin.pattern == SkinPattern::IMAGE) {
+            skin.load_image_from_file(img_path);
+        }
+
+        return true;
+    }
+
+    /**
+     * @brief Save user data to user.ini
+     * @return true if saved successfully
+     */
+    bool save_user() const {
+        ConfigManager config;
+
+        config.set("Profile.username", username);
+        config.set("Network.server_ip", server_ip);
+
+        config.set("Skin.pattern", static_cast<int>(skin.pattern));
+        config.set("Skin.primary_r", static_cast<int>(skin.primary.r));
+        config.set("Skin.primary_g", static_cast<int>(skin.primary.g));
+        config.set("Skin.primary_b", static_cast<int>(skin.primary.b));
+        config.set("Skin.secondary_r", static_cast<int>(skin.secondary.r));
+        config.set("Skin.secondary_g", static_cast<int>(skin.secondary.g));
+        config.set("Skin.secondary_b", static_cast<int>(skin.secondary.b));
+        config.set("Skin.tertiary_r", static_cast<int>(skin.tertiary.r));
+        config.set("Skin.tertiary_g", static_cast<int>(skin.tertiary.g));
+        config.set("Skin.tertiary_b", static_cast<int>(skin.tertiary.b));
+
+        if (!skin.image_path.empty()) {
+            config.set("Skin.image_path", skin.image_path);
+        }
+
+        return config.save(USER_CONFIG_PATH);
+    }
+
+    /**
+     * @brief Load all config files
+     */
+    void load_all_configs() {
+        load_settings();
+        load_user();
+    }
+
+    /**
+     * @brief Save all config files
+     */
+    void save_all_configs() const {
+        save_settings();
+        save_user();
+    }
 };
 
 }  // namespace bagario


### PR DESCRIPTION
  - Add ConfigManager utility for INI file parsing/writing
  - Add settings.ini for audio/video settings (music, sfx, vsync, fullscreen)
  - Add user.ini for profile data (username, server_ip, skin configuration)
  - Load configs on game startup in BagarioGame::initialize()
  - Save settings.ini when leaving Settings screen
  - Save user.ini when leaving Skin screen or clicking Play
  - Move minimap 40px higher (offset from 10px to 50px from bottom)