### PR TITLE
fix: clone vcpkg directly in Dockerfiles instead of using submodule

### DIFF
--- a/Dockerfile.bagario-server
+++ b/Dockerfile.bagario-server
@@ -30,14 +30,14 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /build
 
-# Copy project files
+# Copy project files (excluding vcpkg submodule)
 COPY . .
 
-# Bootstrap vcpkg if needed
-RUN if [ ! -f "vcpkg/vcpkg" ]; then \
-        cd vcpkg && \
-        ./bootstrap-vcpkg.sh -disableMetrics; \
-    fi
+# Clone and bootstrap vcpkg at specific commit (matching CI)
+RUN git clone https://github.com/Microsoft/vcpkg.git vcpkg && \
+    cd vcpkg && \
+    git checkout bd52fac7114fdaa2208de8dd1227212a6683e562 && \
+    ./bootstrap-vcpkg.sh -disableMetrics
 
 # Configure CMake with vcpkg for ARM64 dynamic linking
 RUN cmake -S . -B build \

--- a/Dockerfile.rtype-server
+++ b/Dockerfile.rtype-server
@@ -30,14 +30,14 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /build
 
-# Copy project files
+# Copy project files (excluding vcpkg submodule)
 COPY . .
 
-# Bootstrap vcpkg if needed
-RUN if [ ! -f "vcpkg/vcpkg" ]; then \
-        cd vcpkg && \
-        ./bootstrap-vcpkg.sh -disableMetrics; \
-    fi
+# Clone and bootstrap vcpkg at specific commit (matching CI)
+RUN git clone https://github.com/Microsoft/vcpkg.git vcpkg && \
+    cd vcpkg && \
+    git checkout bd52fac7114fdaa2208de8dd1227212a6683e562 && \
+    ./bootstrap-vcpkg.sh -disableMetrics
 
 # Configure CMake with vcpkg for ARM64 dynamic linking
 RUN cmake -S . -B build \


### PR DESCRIPTION
This pull request updates the Docker build process for both `bagario-server` and `rtype-server` to ensure that the `vcpkg` dependency manager is always cloned at a specific commit, matching the CI environment. This change improves build consistency and reliability by avoiding potential issues with local or outdated submodules.

**Docker build improvements:**

* Updated `Dockerfile.bagario-server` and `Dockerfile.rtype-server` to always clone the `vcpkg` repository at the specific commit `bd52fac7114fdaa2208de8dd1227212a6683e562` during the build process, rather than relying on a potentially stale submodule or local copy. [[1]](diffhunk://#diff-fa7f5bc67488a2608745e458b9d8d99a1b2a4cc4a97ef799083d857875f080e6L33-R40) [[2]](diffhunk://#diff-0fc926d1884c6ccbe7510f44514d9d908f6bdbc6e65366bd623932ee7c584a1bL33-R40)
* Modified comments to clarify that project files are copied excluding the `vcpkg` submodule, and updated the vcpkg bootstrapping step accordingly. [[1]](diffhunk://#diff-fa7f5bc67488a2608745e458b9d8d99a1b2a4cc4a97ef799083d857875f080e6L33-R40) [[2]](diffhunk://#diff-0fc926d1884c6ccbe7510f44514d9d908f6bdbc6e65366bd623932ee7c584a1bL33-R40)