### PR TITLE
fix: ARM not available on private repo

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,7 +25,8 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-24.04-arm  # Native ARM64 runner for fast builds
+    runs-on: ubuntu-latest
+    timeout-minutes: 120  # Increased timeout for ARM64 emulation
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
This pull request makes a minor adjustment to the deployment workflow by changing the runner environment and increasing the job timeout. The job now uses the default `ubuntu-latest` runner instead of a native ARM64 runner, and the timeout has been extended to accommodate ARM64 emulation.

- Deployment workflow update:
  * Changed the `runs-on` parameter from `ubuntu-24.04-arm` to `ubuntu-latest` and set `timeout-minutes` to 120 in `.github/workflows/deploy.yaml`.