### PR TITLE
fix: add actuel branch to builder image

### DIFF
--- a/.github/workflows/build-base-image.yaml
+++ b/.github/workflows/build-base-image.yaml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - 200-prod-ci-prod-installer
     paths:
       - 'Dockerfile.builder'
       - 'vcpkg.json'
@@ -18,7 +19,8 @@ env:
 
 jobs:
   build-base-image:
-    runs-on: ubuntu-24.04-arm  # Native ARM64 runner
+    runs-on: ubuntu-latest
+    timeout-minutes: 180  # Long timeout for ARM64 build with QEMU emulation
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building the base image. The main changes are to expand the branches that trigger the workflow and to adjust the build environment for better compatibility and reliability.

Workflow trigger updates:

* The workflow will now also run on pushes to the `200-prod-ci-prod-installer` branch, in addition to `main`.

Build environment and configuration changes:

* The build job now runs on `ubuntu-latest` instead of the native ARM64 runner (`ubuntu-24.04-arm`), and a longer timeout of 180 minutes has been set to accommodate the ARM64 build using QEMU emulation.