### PR TITLE
ci: trigger build-base-image workflow on push

### DIFF
--- a/.github/workflows/build-base-image.yaml
+++ b/.github/workflows/build-base-image.yaml
@@ -8,10 +8,12 @@ on:
   push:
     branches:
       - main
+      - test-CI
       - 200-prod-ci-prod-installer
     paths:
       - 'Dockerfile.builder'
       - 'vcpkg.json'
+      - '.github/workflows/build-base-image.yaml'
 
 env:
   REGISTRY: registry.eliasdrissi.dev


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow configuration by adding the `test-CI` branch to the list of branches that trigger the `build-base-image` workflow. This ensures that changes pushed to `test-CI` will also run the workflow.