### PR TITLE
fix: error vcpkg

### DIFF
--- a/Dockerfile.bagario-server
+++ b/Dockerfile.bagario-server
@@ -38,18 +38,16 @@ RUN git clone --depth 1 --branch master https://github.com/Microsoft/vcpkg.git .
     git checkout ${VCPKG_COMMIT} && \
     ./bootstrap-vcpkg.sh -disableMetrics
 
-# Pre-install dependencies
-WORKDIR /prebuild
-COPY vcpkg.json .
-RUN /vcpkg/vcpkg install --triplet arm64-linux-dynamic && \
-    rm -rf /vcpkg/.git /vcpkg/buildtrees /vcpkg/downloads /vcpkg/packages
-
 ENV VCPKG_ROOT=/vcpkg
 ENV VCPKG_DEFAULT_TRIPLET=arm64-linux-dynamic
 
-WORKDIR /build
+# Pre-install vcpkg dependencies (separate from build)
+WORKDIR /tmp/vcpkg-prebuild
+COPY vcpkg.json .
+RUN /vcpkg/vcpkg install --triplet arm64-linux-dynamic
 
-# Copy only necessary files for build (better cache)
+# Setup build directory and copy files
+WORKDIR /build
 COPY CMakeLists.txt .
 COPY cmake/ cmake/
 COPY src/ src/
@@ -68,7 +66,8 @@ RUN cmake -S . -B build \
     -DBUILD_BAGARIO=ON
 
 # Build Bagario server only
-RUN cmake --build build --target bagario_server -j$(nproc)
+RUN cmake --build build --target bagario_server -j$(nproc) && \
+    rm -rf /vcpkg/.git /vcpkg/buildtrees /vcpkg/downloads /vcpkg/packages
 
 # Verify the binary exists
 RUN ls -lh /build/build/bin/bagario_server

--- a/Dockerfile.rtype-server
+++ b/Dockerfile.rtype-server
@@ -38,18 +38,16 @@ RUN git clone --depth 1 --branch master https://github.com/Microsoft/vcpkg.git .
     git checkout ${VCPKG_COMMIT} && \
     ./bootstrap-vcpkg.sh -disableMetrics
 
-# Pre-install dependencies
-WORKDIR /prebuild
-COPY vcpkg.json .
-RUN /vcpkg/vcpkg install --triplet arm64-linux-dynamic && \
-    rm -rf /vcpkg/.git /vcpkg/buildtrees /vcpkg/downloads /vcpkg/packages
-
 ENV VCPKG_ROOT=/vcpkg
 ENV VCPKG_DEFAULT_TRIPLET=arm64-linux-dynamic
 
-WORKDIR /build
+# Pre-install vcpkg dependencies (separate from build)
+WORKDIR /tmp/vcpkg-prebuild
+COPY vcpkg.json .
+RUN /vcpkg/vcpkg install --triplet arm64-linux-dynamic
 
-# Copy only necessary files for build (better cache)
+# Setup build directory and copy files
+WORKDIR /build
 COPY CMakeLists.txt .
 COPY cmake/ cmake/
 COPY src/ src/
@@ -68,7 +66,8 @@ RUN cmake -S . -B build \
     -DBUILD_BAGARIO=OFF
 
 # Build R-Type server only
-RUN cmake --build build --target r-type_server -j$(nproc)
+RUN cmake --build build --target r-type_server -j$(nproc) && \
+    rm -rf /vcpkg/.git /vcpkg/buildtrees /vcpkg/downloads /vcpkg/packages
 
 # Verify the binary exists
 RUN ls -lh /build/build/r-type_server


### PR DESCRIPTION
This pull request refactors the Docker build process for both the Bagario and R-Type server images to improve build caching and reduce image size. The main changes involve separating the vcpkg dependency installation from the build setup and cleaning up unnecessary vcpkg files after the build.

**Dockerfile improvements:**

* Separated the vcpkg dependency installation into a dedicated prebuild directory (`/tmp/vcpkg-prebuild`) to improve build caching and organization in both `Dockerfile.bagario-server` and `Dockerfile.rtype-server`. [[1]](diffhunk://#diff-fa7f5bc67488a2608745e458b9d8d99a1b2a4cc4a97ef799083d857875f080e6L41-R50) [[2]](diffhunk://#diff-0fc926d1884c6ccbe7510f44514d9d908f6bdbc6e65366bd623932ee7c584a1bL41-R50)
* Removed the cleanup of vcpkg files (`.git`, `buildtrees`, `downloads`, `packages`) from the dependency installation step and moved it to after the build step for both servers, ensuring only necessary files remain in the final image. [[1]](diffhunk://#diff-fa7f5bc67488a2608745e458b9d8d99a1b2a4cc4a97ef799083d857875f080e6L71-R70) [[2]](diffhunk://#diff-0fc926d1884c6ccbe7510f44514d9d908f6bdbc6e65366bd623932ee7c584a1bL71-R70)