### PR TITLE
fix: error assests

### DIFF
--- a/Dockerfile.bagario-server
+++ b/Dockerfile.bagario-server
@@ -52,6 +52,7 @@ COPY CMakeLists.txt .
 COPY cmake/ cmake/
 COPY src/ src/
 COPY vcpkg.json .
+COPY assets/ assets/
 
 # Configure CMake with pre-installed vcpkg
 RUN cmake -S . -B build \

--- a/Dockerfile.rtype-server
+++ b/Dockerfile.rtype-server
@@ -52,6 +52,7 @@ COPY CMakeLists.txt .
 COPY cmake/ cmake/
 COPY src/ src/
 COPY vcpkg.json .
+COPY assets/ assets/
 
 # Configure CMake with pre-installed vcpkg
 RUN cmake -S . -B build \


### PR DESCRIPTION
This pull request updates the Docker build process for both the Bagario and RType server images to ensure that the `assets/` directory is included in the Docker image. This change helps guarantee that all necessary assets are available at runtime.

Build process improvements:

* Updated `Dockerfile.bagario-server` to copy the `assets/` directory into the image, ensuring assets are present for the Bagario server.
* Updated `Dockerfile.rtype-server` to copy the `assets/` directory into the image, ensuring assets are present for the RType server.