### PR TITLE
fix: error build dockerfile bagario

### DIFF
--- a/Dockerfile.bagario-server
+++ b/Dockerfile.bagario-server
@@ -67,11 +67,17 @@ RUN cmake -S . -B build \
     -DBUILD_BAGARIO=ON
 
 # Build Bagario server only
-RUN cmake --build build --target bagario_server -j$(nproc) && \
-    rm -rf /vcpkg/.git /vcpkg/buildtrees /vcpkg/downloads /vcpkg/packages
+RUN cmake --build build --target bagario_server -j$(nproc)
 
-# Verify the binary exists
+# Debug: List build directory structure
+RUN echo "=== Build directory structure ===" && \
+    find /build/build -type f -name "*bagario*" -o -name "*server*" | head -20
+
+# Verify the binary exists before cleanup
 RUN ls -lh /build/build/bin/bagario_server
+
+# Cleanup vcpkg cache
+RUN rm -rf /vcpkg/.git /vcpkg/buildtrees /vcpkg/downloads /vcpkg/packages
 
 # ==========================================
 # STAGE 2: Runtime (Production)


### PR DESCRIPTION
This pull request updates the Docker build process for the Bagario server, primarily to improve build debugging and reliability. The most important changes are focused on making it easier to verify the build output before cleaning up build dependencies.

**Build process improvements:**

* Added a debug step to list the contents of the build directory after building `bagario_server`, making it easier to confirm the binary and related files were generated correctly.
* Moved the cleanup of the vcpkg cache to after the verification steps, ensuring that important build artifacts are not accidentally removed before they're checked.