### PR TITLE
fix: error build add rule in cmake for bagario

### DIFF
--- a/src/bagario/CMakeLists.txt
+++ b/src/bagario/CMakeLists.txt
@@ -2,6 +2,10 @@ add_subdirectory(shared)
 
 add_subdirectory(game-logic)
 
-add_subdirectory(server)
+if(BUILD_SERVER)
+    add_subdirectory(server)
+endif()
 
-add_subdirectory(client)
+if(BUILD_CLIENT)
+    add_subdirectory(client)
+endif()


### PR DESCRIPTION
This pull request updates the `src/bagario/CMakeLists.txt` build configuration to conditionally include the `server` and `client` subdirectories only when the corresponding build options are enabled.

Build configuration improvements:

* The `server` subdirectory is now only added if the `BUILD_SERVER` option is set.
* The `client` subdirectory is now only added if the `BUILD_CLIENT` option is set.