### PR TITLE
feat: remove text to restart CI

### DIFF
--- a/Dockerfile.rtype-server
+++ b/Dockerfile.rtype-server
@@ -2,7 +2,7 @@
 # R-Type Server Production Dockerfile
 # Target: ARM64 (Raspberry Pi)
 # ==========================================
-# Builds with vcpkg dependencies inline (no separate builder image)
+# Builds with vcpkg dependencies inline
 # ==========================================
 
 # ==========================================


### PR DESCRIPTION
This pull request makes a minor documentation update to the `Dockerfile.rtype-server` file, clarifying the comment about how vcpkg dependencies are built. The change removes the note about not using a separate builder image.