### PR TITLE
feat: fixing procedural generation

### DIFF
--- a/docs/WAVE_SYSTEM.md
+++ b/docs/WAVE_SYSTEM.md
@@ -312,12 +312,14 @@ src/r-type/game-logic/
 │   ├── components/
 │   │   ├── GameComponents.hpp     # Wave components definitions
 │   │   └── WaveConfig.hpp         # Wave configuration defines
-│   └── systems/
-│       ├── WaveSpawnerSystem.hpp  # Wave spawner system header
+│   ├── systems/
+│   │   └── WaveSpawnerSystem.hpp  # Wave spawner system header
+│   └── utils/
 │       └── WaveConfigLoader.hpp   # JSON loader header
 └── src/
-    └── systems/
-        ├── WaveSpawnerSystem.cpp  # Wave spawner implementation
+    ├── systems/
+    │   └── WaveSpawnerSystem.cpp  # Wave spawner implementation
+    └── utils/
         └── WaveConfigLoader.cpp   # JSON loader implementation
 
 src/r-type/assets/

--- a/src/r-type/client/include/NetworkClient.hpp
+++ b/src/r-type/client/include/NetworkClient.hpp
@@ -177,7 +177,7 @@ public:
      * @brief Set callback for game start
      * @param callback Function receiving session_id, udp_port, map_id and scroll speed
      */
-    void set_on_game_start(std::function<void(uint32_t session_id, uint16_t udp_port, uint16_t map_id, float scroll_speed)> callback);
+    void set_on_game_start(std::function<void(uint32_t session_id, uint16_t udp_port, uint16_t map_id, float scroll_speed, uint32_t seed)> callback);
 
     /**
      * @brief Set callback for entity spawn
@@ -399,7 +399,7 @@ private:
     std::function<void(uint8_t, const std::string&)> on_rejected_;
     std::function<void(const protocol::ServerLobbyStatePayload&, const std::vector<protocol::PlayerLobbyEntry>&)> on_lobby_state_;
     std::function<void(uint8_t)> on_countdown_;
-    std::function<void(uint32_t, uint16_t, uint16_t, float)> on_game_start_;
+    std::function<void(uint32_t, uint16_t, uint16_t, float, uint32_t)> on_game_start_;
     std::function<void(const protocol::ServerEntitySpawnPayload&)> on_entity_spawn_;
     std::function<void(const protocol::ServerEntityDestroyPayload&)> on_entity_destroy_;
     std::function<void(const protocol::ServerProjectileSpawnPayload&)> on_projectile_spawn_;

--- a/src/r-type/client/src/ClientGame.cpp
+++ b/src/r-type/client/src/ClientGame.cpp
@@ -562,7 +562,7 @@ void ClientGame::setup_network_callbacks() {
         status_overlay_->refresh();
     });
 
-    network_client_->set_on_game_start([this](uint32_t session_id, uint16_t udp_port, uint16_t map_id, float scroll_speed) {
+    network_client_->set_on_game_start([this](uint32_t session_id, uint16_t udp_port, uint16_t map_id, float scroll_speed, uint32_t seed) {
         (void)udp_port;
         status_overlay_->set_session("In game (session " + std::to_string(session_id) + ")");
         status_overlay_->refresh();
@@ -609,6 +609,10 @@ void ClientGame::setup_network_callbacks() {
         if (chunk_manager_) {
             // Pass registry to update velocities of existing wall entities
             chunk_manager_->setScrollSpeed(server_scroll_speed_, registry_.get());
+            
+            // Set the map seed for procedural generation (ensure this happens AFTER map load/init)
+            // load_map() resets the generator with config seed, so we must override it here
+            chunk_manager_->setProceduralSeed(seed);
         }
 
         // Apply map-specific theme (background color)

--- a/src/r-type/client/src/NetworkClient.cpp
+++ b/src/r-type/client/src/NetworkClient.cpp
@@ -488,17 +488,19 @@ void NetworkClient::handle_game_start(const std::vector<uint8_t>& payload) {
     udp_port_ = ntohs(game_start.udp_port);
     uint16_t map_id = ntohs(game_start.map_id);
     float scroll_speed = game_start.scroll_speed;
+    uint32_t level_seed = ntohl(game_start.level_seed);
     in_lobby_ = false;
     in_game_ = true;
 
     // std::cout << "[NetworkClient] Game started! Session: " << session_id_
-    //           << ", UDP port: " << udp_port_ << ", Map: " << map_id << "\n";
+    //           << ", UDP port: " << udp_port_ << ", Map: " << map_id 
+    //           << ", Seed: " << level_seed << "\n";
 
     // Connect UDP for gameplay
     connect_udp(udp_port_);
 
     if (on_game_start_)
-        on_game_start_(session_id_, udp_port_, map_id, scroll_speed);
+        on_game_start_(session_id_, udp_port_, map_id, scroll_speed, level_seed);
 }
 
 void NetworkClient::handle_entity_spawn(const std::vector<uint8_t>& payload) {
@@ -928,7 +930,7 @@ void NetworkClient::set_on_countdown(std::function<void(uint8_t)> callback) {
     on_countdown_ = callback;
 }
 
-void NetworkClient::set_on_game_start(std::function<void(uint32_t, uint16_t, uint16_t, float)> callback) {
+void NetworkClient::set_on_game_start(std::function<void(uint32_t, uint16_t, uint16_t, float, uint32_t)> callback) {
     on_game_start_ = callback;
 }
 

--- a/src/r-type/client/src/test_network.cpp
+++ b/src/r-type/client/src/test_network.cpp
@@ -116,10 +116,11 @@ int main(int argc, char* argv[]) {
         std::cout << "[TestClient] COUNTDOWN: " << (int)seconds << " seconds\n";
     });
 
-    client.set_on_game_start([&client](uint32_t session_id, uint16_t udp_port, uint16_t map_id, float scroll_speed) {
+    client.set_on_game_start([&client](uint32_t session_id, uint16_t udp_port, uint16_t map_id, float scroll_speed, uint32_t seed) {
         std::cout << "[TestClient] GAME START! Session: " << session_id
                   << ", UDP port: " << udp_port << ", Map: " << map_id
-                  << ", Scroll speed: " << scroll_speed << "\n";
+                  << ", Scroll speed: " << scroll_speed 
+                  << ", Seed: " << seed << "\n";
         std::cout << "[TestClient] UDP connection should be automatic...\n";
     });
 

--- a/src/r-type/game-logic/src/ChunkManagerSystem.cpp
+++ b/src/r-type/game-logic/src/ChunkManagerSystem.cpp
@@ -464,7 +464,13 @@ void ChunkManagerSystem::setProceduralSeed(uint32_t seed) {
     m_generator = std::make_unique<ProceduralMapGenerator>(seed);
     m_generatedSegments.clear();
 
-    std::cout << "[ChunkManagerSystem] Procedural seed set to: " << seed << std::endl;
+    // FORCE RESET of active chunks to ensure we don't keep any segments generated with the old seed
+    m_activeChunks.clear();
+    m_nextChunkIndex = 0;
+    m_currentSegment = 0;
+    // Do NOT reset scroll position here as it might be set by server already
+    
+    std::cout << "[ChunkManagerSystem] Procedural seed set to: " << seed << " (Chunks reset)" << std::endl;
 }
 
 SegmentData* ChunkManagerSystem::getOrGenerateSegment(int segmentId) {

--- a/src/r-type/server/include/GameSession.hpp
+++ b/src/r-type/server/include/GameSession.hpp
@@ -114,6 +114,7 @@ public:
     ServerNetworkSystem* get_network_system() { return network_system_; }
     float get_scroll_speed() const { return scroll_speed_; }
     double get_current_scroll() const { return current_scroll_; }  // NEW: For checkpoint system
+    uint32_t get_map_seed() const { return map_seed_; }
 
     /**
      * @brief Resync a client with all existing entities

--- a/src/r-type/server/src/Server.cpp
+++ b/src/r-type/server/src/Server.cpp
@@ -428,7 +428,7 @@ void Server::on_game_start(uint32_t lobby_id, const std::vector<uint32_t>& playe
         game_start.game_mode = game_mode;
         game_start.difficulty = difficulty;
         game_start.server_tick = ByteOrder::host_to_net32(0);
-        game_start.level_seed = ByteOrder::host_to_net32(0);
+        game_start.level_seed = ByteOrder::host_to_net32(session->get_map_seed());
         game_start.udp_port = ByteOrder::host_to_net16(udp_port_);
         game_start.map_id = ByteOrder::host_to_net16(map_id);
         game_start.scroll_speed = session->get_scroll_speed();


### PR DESCRIPTION
This pull request primarily updates the game's network protocol and procedural map generation to support transmitting and synchronizing a map seed from the server to all clients. This ensures that procedural content (such as map chunks) is consistent across all players. The changes also improve the documentation structure and ensure that resetting the procedural seed properly resets generated map segments on the client.

**Network protocol and procedural seed synchronization:**

* The `on_game_start` callback in `NetworkClient` and related code now includes a `seed` parameter (`uint32_t`), allowing the server to send the procedural map seed to clients. This affects the callback signatures in `NetworkClient.hpp`, its implementation in `NetworkClient.cpp`, the client game logic in `ClientGame.cpp`, and the network test client (`test_network.cpp`). [[1]](diffhunk://#diff-6dd8e427e67f9b9706f7b3bff7e258bd77f7bb4d218d145321f992d6cc5f64e5L180-R180) [[2]](diffhunk://#diff-6dd8e427e67f9b9706f7b3bff7e258bd77f7bb4d218d145321f992d6cc5f64e5L402-R402) [[3]](diffhunk://#diff-538ae0bb275f61845e460567cd929ab5c5885f9d0ba291668319957d2508637bL565-R565) [[4]](diffhunk://#diff-711acb782644f33c3ab9bc9a9584f42c937f1009de735fe3558f4345262d7468R491-R503) [[5]](diffhunk://#diff-711acb782644f33c3ab9bc9a9584f42c937f1009de735fe3558f4345262d7468L931-R933) [[6]](diffhunk://#diff-cac58ab3ce768b23f6cb8618a1486856a4e84bc084792af673258a9c13d1f9f1L119-R123)
* The server now sends the actual map seed (from `GameSession::get_map_seed()`) in the game start packet, ensuring all clients receive the correct seed for procedural generation. [[1]](diffhunk://#diff-c856f0df18c13b8896e301d0e1cc7be501c8322fd1f85a80a8854574fde79785R117) [[2]](diffhunk://#diff-536b7f76baf989618a88c0eea1d2e640b1fc46647fbb4832ab9970331b93e6fcL431-R431)
* The client sets the procedural seed in the `ChunkManagerSystem` after loading the map, guaranteeing that procedural content is generated using the correct seed received from the server.

**Procedural map generator reset improvements:**

* When setting a new procedural seed in `ChunkManagerSystem`, all active and generated chunks are now cleared, and indices are reset to prevent inconsistencies from previous seeds. The scroll position is preserved as it may be set by the server.

**Documentation and code organization:**

* The directory structure in `docs/WAVE_SYSTEM.md` is updated to reflect the new organization, separating `systems` and `utils` folders for better clarity.