### PR TITLE
fix: print debug to fix CI

### DIFF
--- a/Dockerfile.bagario-server
+++ b/Dockerfile.bagario-server
@@ -70,8 +70,12 @@ RUN cmake -S . -B build \
 RUN cmake --build build --target bagario_server -j$(nproc)
 
 # Debug: List build directory structure
-RUN echo "=== Build directory structure ===" && \
-    find /build/build -type f -name "*bagario*" -o -name "*server*" | head -20
+RUN echo "=== Listing /build/build contents ===" && \
+    ls -la /build/build/ && \
+    echo "=== Checking for bin directory ===" && \
+    ls -la /build/build/bin/ || echo "bin/ does not exist" && \
+    echo "=== Finding all executables ===" && \
+    find /build/build -type f -executable || echo "No executables found"
 
 # Verify the binary exists before cleanup
 RUN ls -lh /build/build/bin/bagario_server


### PR DESCRIPTION
This pull request updates the debug and verification steps in the `Dockerfile.bagario-server` to provide more detailed and reliable output when inspecting the build directory after compiling the server.

**Improvements to build directory inspection and debugging:**

* Enhanced the post-build debugging step to list the contents of `/build/build/`, explicitly check for the existence of the `bin/` directory, and search for all executable files, making it easier to diagnose build issues.