### PR TITLE
fix: build asio and enet for both server

### DIFF
--- a/Dockerfile.bagario-server
+++ b/Dockerfile.bagario-server
@@ -66,11 +66,11 @@ RUN cmake -S . -B build \
     -DBUILD_RTYPE=OFF \
     -DBUILD_BAGARIO=ON
 
-# Build Bagario server only
-RUN cmake --build build --target bagario_server -j$(nproc)
+# Build Bagario server and required network plugin
+RUN cmake --build build --target bagario_server enet_network -j$(nproc)
 
-# Verify the binary exists and cleanup vcpkg cache
-RUN ls -lh /build/build/bagario_server && \
+# Verify the binary and plugin exist, then cleanup vcpkg cache
+RUN ls -lh /build/build/bagario_server /build/build/plugins/enet_network.so && \
     rm -rf /vcpkg/.git /vcpkg/buildtrees /vcpkg/downloads /vcpkg/packages
 
 # ==========================================

--- a/Dockerfile.rtype-server
+++ b/Dockerfile.rtype-server
@@ -66,12 +66,12 @@ RUN cmake -S . -B build \
     -DBUILD_RTYPE=ON \
     -DBUILD_BAGARIO=OFF
 
-# Build R-Type server only
-RUN cmake --build build --target r-type_server -j$(nproc) && \
+# Build R-Type server and required network plugin
+RUN cmake --build build --target r-type_server asio_network -j$(nproc) && \
     rm -rf /vcpkg/.git /vcpkg/buildtrees /vcpkg/downloads /vcpkg/packages
 
-# Verify the binary exists
-RUN ls -lh /build/build/r-type_server
+# Verify the binary and plugin exist
+RUN ls -lh /build/build/r-type_server /build/build/plugins/asio_network.so
 
 # ==========================================
 # STAGE 2: Runtime (Production)


### PR DESCRIPTION
This pull request updates the build steps in the Dockerfiles for both the Bagario and R-Type servers to ensure their required network plugins are built and verified alongside the server binaries. The changes improve reliability by explicitly building and checking for plugin presence during the image build process.

**Build process improvements:**

* The Bagario server Dockerfile now builds both the `bagario_server` binary and the `enet_network` plugin, and verifies that both files exist after the build. (`Dockerfile.bagario-server`)
* The R-Type server Dockerfile now builds both the `r-type_server` binary and the `asio_network` plugin, and verifies that both files exist after the build. (`Dockerfile.rtype-server`)