### PR TITLE
fix: error path for plugin in the CI which was not in /plugin but in …

### DIFF
--- a/Dockerfile.bagario-server
+++ b/Dockerfile.bagario-server
@@ -70,7 +70,7 @@ RUN cmake -S . -B build \
 RUN cmake --build build --target bagario_server enet_network -j$(nproc)
 
 # Verify the binary and plugin exist, then cleanup vcpkg cache
-RUN ls -lh /build/build/bagario_server /build/build/plugins/enet_network.so && \
+RUN ls -lh /build/build/bagario_server /build/build/enet_network.so && \
     rm -rf /vcpkg/.git /vcpkg/buildtrees /vcpkg/downloads /vcpkg/packages
 
 # ==========================================
@@ -90,8 +90,9 @@ WORKDIR /app
 # Copy the server binary
 COPY --from=builder /build/build/bagario_server /app/bagario_server
 
-# Copy network plugins (enet_network.so required by bagario server)
-COPY --from=builder /build/build/plugins /app/plugins
+# Copy network plugin (enet_network.so required by bagario server)
+RUN mkdir -p /app/plugins
+COPY --from=builder /build/build/enet_network.so /app/plugins/enet_network.so
 
 # Copy vcpkg dynamic libraries
 COPY --from=builder /build/build/vcpkg_installed/arm64-linux-dynamic/lib /app/lib

--- a/Dockerfile.rtype-server
+++ b/Dockerfile.rtype-server
@@ -75,18 +75,9 @@ RUN cmake --build build --target asio_network -j$(nproc) || echo "asio_network b
 # Build R-Type server
 RUN cmake --build build --target r-type_server -j$(nproc)
 
-# Debug: Check what was built
-RUN echo "=== Build output structure ===" && \
-    ls -la /build/build/ && \
-    echo "=== Checking for plugins directory ===" && \
-    ls -la /build/build/plugins/ 2>/dev/null || echo "plugins/ directory does not exist"
-
-# Verify the binary exists (plugin is optional for now to debug)
-RUN ls -lh /build/build/r-type_server && \
-    (ls -lh /build/build/plugins/asio_network.so || echo "WARNING: asio_network.so not found")
-
-# Cleanup vcpkg cache
-RUN rm -rf /vcpkg/.git /vcpkg/buildtrees /vcpkg/downloads /vcpkg/packages
+# Verify the binary and plugin exist, then cleanup
+RUN ls -lh /build/build/r-type_server /build/build/asio_network.so && \
+    rm -rf /vcpkg/.git /vcpkg/buildtrees /vcpkg/downloads /vcpkg/packages
 
 # ==========================================
 # STAGE 2: Runtime (Production)
@@ -105,8 +96,9 @@ WORKDIR /app
 # Copy the server binary
 COPY --from=builder /build/build/r-type_server /app/r-type_server
 
-# Copy network plugins (asio_network.so required by r-type server)
-COPY --from=builder /build/build/plugins /app/plugins
+# Copy network plugin (asio_network.so required by r-type server)
+RUN mkdir -p /app/plugins
+COPY --from=builder /build/build/asio_network.so /app/plugins/asio_network.so
 
 # Copy vcpkg dynamic libraries
 COPY --from=builder /build/build/vcpkg_installed/arm64-linux-dynamic/lib /app/lib


### PR DESCRIPTION

This pull request updates the Docker build and packaging process for both the Bagario and R-Type servers to improve plugin handling and streamline the image structure. The main focus is on simplifying how network plugin `.so` files are built, verified, and copied into the runtime image, removing unnecessary directory nesting and debug steps.

**Dockerfile improvements for plugin handling:**

- **Plugin file path simplification:**
  - Changed the build and verification steps to expect plugin `.so` files (`enet_network.so`, `asio_network.so`) directly in the build directory, rather than in a nested `plugins/` directory. [[1]](diffhunk://#diff-fa7f5bc67488a2608745e458b9d8d99a1b2a4cc4a97ef799083d857875f080e6L73-R73) [[2]](diffhunk://#diff-0fc926d1884c6ccbe7510f44514d9d908f6bdbc6e65366bd623932ee7c584a1bL78-R80)

- **Copying plugins into runtime image:**
  - Updated the Dockerfiles to create the `/app/plugins` directory explicitly and copy each required plugin `.so` file individually, instead of copying an entire `plugins/` directory. [[1]](diffhunk://#diff-fa7f5bc67488a2608745e458b9d8d99a1b2a4cc4a97ef799083d857875f080e6L93-R95) [[2]](diffhunk://#diff-0fc926d1884c6ccbe7510f44514d9d908f6bdbc6e65366bd623932ee7c584a1bL108-R101)

**Build process cleanup:**

- **Removed debug and optional plugin checks:**
  - Eliminated unnecessary debug output and conditional plugin checks from the R-Type server Dockerfile to streamline the build process.

These changes make the Docker images cleaner, reduce potential confusion around plugin locations, and ensure that only the required files are included in the runtime environment.