### PR TITLE
fix: missing --network in docker start command for production

### DIFF
--- a/Dockerfile.bagario-server
+++ b/Dockerfile.bagario-server
@@ -118,5 +118,5 @@ USER bagario
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD timeout 2 bash -c "echo -n > /dev/tcp/127.0.0.1/4444" || exit 1
 
-# Default command
-CMD ["/app/bagario_server"]
+# Default command (--network to listen on all interfaces for production)
+CMD ["/app/bagario_server", "--network"]

--- a/Dockerfile.rtype-server
+++ b/Dockerfile.rtype-server
@@ -124,5 +124,5 @@ USER rtype
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD timeout 2 bash -c "echo -n > /dev/tcp/127.0.0.1/4242" || exit 1
 
-# Default command
-CMD ["/app/r-type_server"]
+# Default command (--network to listen on all interfaces for production)
+CMD ["/app/r-type_server", "--network"]


### PR DESCRIPTION
This pull request updates the default startup commands in the Dockerfiles for both the `bagario_server` and `r-type_server` services. The main change ensures that each server listens on all network interfaces, which is important for production deployments.

Dockerfile command updates:

* [`Dockerfile.bagario-server`](diffhunk://#diff-fa7f5bc67488a2608745e458b9d8d99a1b2a4cc4a97ef799083d857875f080e6L121-R122): Modified the default command to add the `--network` flag, allowing `bagario_server` to listen on all interfaces.
* [`Dockerfile.rtype-server`](diffhunk://#diff-0fc926d1884c6ccbe7510f44514d9d908f6bdbc6e65366bd623932ee7c584a1bL127-R128): Modified the default command to add the `--network` flag, allowing `r-type_server` to listen on all interfaces.