### PR TITLE
Fixhealthprod

### DIFF
--- a/Dockerfile.bagario-server
+++ b/Dockerfile.bagario-server
@@ -83,6 +83,7 @@ RUN apt-get update && apt-get install -y \
     libstdc++6 \
     libc6 \
     libgcc-s1 \
+    netcat-openbsd \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -114,9 +115,9 @@ RUN useradd -m -u 1001 bagario && \
 
 USER bagario
 
-# Health check
+# Health check using netcat
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD timeout 2 bash -c "echo -n > /dev/tcp/127.0.0.1/4444" || exit 1
+    CMD nc -z 127.0.0.1 4444 || exit 1
 
 # Default command (--network to listen on all interfaces for production)
 CMD ["/app/bagario_server", "--network"]


### PR DESCRIPTION
This pull request updates the `Dockerfile.bagario-server` to improve the container health check and ensure the necessary dependencies are installed for reliable health monitoring.

Dependency updates:

* Added the installation of `netcat-openbsd` to the list of required packages to support the new health check mechanism.

Health check improvements:

* Changed the health check command to use `nc -z` (netcat) for checking if port 4444 is open, replacing the previous Bash-based TCP check for better reliability and clarity.