### PR TITLE
fix: enet only udp mode

### DIFF
--- a/Dockerfile.bagario-server
+++ b/Dockerfile.bagario-server
@@ -83,7 +83,7 @@ RUN apt-get update && apt-get install -y \
     libstdc++6 \
     libc6 \
     libgcc-s1 \
-    netcat-openbsd \
+    procps \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -115,9 +115,9 @@ RUN useradd -m -u 1001 bagario && \
 
 USER bagario
 
-# Health check using netcat
+# Health check - ENet uses UDP only, so we check if the process is running
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD nc -z 127.0.0.1 4444 || exit 1
+    CMD pgrep -x bagario_server > /dev/null || exit 1
 
 # Default command (--network to listen on all interfaces for production)
 CMD ["/app/bagario_server", "--network"]


### PR DESCRIPTION
This pull request updates the `Dockerfile.bagario-server` to improve compatibility and reliability of the container environment. The most important changes include replacing the `netcat-openbsd` package with `procps` and updating the health check to use a process-based approach, which better aligns with the server's UDP-only networking.

**Container environment updates:**

* Replaced installation of `netcat-openbsd` with `procps` in the package list to support process monitoring tools needed for the new health check.

**Health check improvements:**

* Updated the health check command to use `pgrep` from `procps` to verify that `bagario_server` is running, instead of checking for a TCP port with `nc`. This is more appropriate since ENet uses UDP only.