### PR TITLE
Test CI

### DIFF
--- a/Dockerfile.bagario-server
+++ b/Dockerfile.bagario-server
@@ -105,9 +105,8 @@ COPY --from=builder /build/assets /app/assets
 # Set library path for dynamic linking
 ENV LD_LIBRARY_PATH=/app/lib
 
-# Expose ports (TCP + UDP)
-EXPOSE 4444/tcp
-EXPOSE 4545/udp
+# Expose ports (ENet uses UDP only on primary port)
+EXPOSE 4444/udp
 
 # Create a non-root user for security
 RUN useradd -m -u 1001 bagario && \

--- a/src/bagario/client/include/screens/WelcomeScreen.hpp
+++ b/src/bagario/client/include/screens/WelcomeScreen.hpp
@@ -33,8 +33,7 @@ private:
     std::vector<std::unique_ptr<UIButton>> buttons_;
     std::unique_ptr<UITextField> username_field_;
     std::unique_ptr<UITextField> ip_field_;
-    std::unique_ptr<UITextField> tcp_port_field_;
-    std::unique_ptr<UITextField> udp_port_field_;
+    std::unique_ptr<UITextField> port_field_;
     ScreenChangeCallback on_screen_change_;
 };
 

--- a/src/bagario/client/src/screens/PlayingScreen.cpp
+++ b/src/bagario/client/src/screens/PlayingScreen.cpp
@@ -94,7 +94,7 @@ void PlayingScreen::on_enter() {
     if (client_game_state_)
         client_game_state_->clear();
     if (network_) {
-        if (network_->connect(game_state_.server_ip, game_state_.server_tcp_port, game_state_.server_udp_port)) {
+        if (network_->connect(game_state_.server_ip, game_state_.server_port, game_state_.server_port)) {
             // Connection initiated, wait for on_connected callback
             // Then request join will be sent
         } else {

--- a/src/bagario/client/src/screens/WelcomeScreen.cpp
+++ b/src/bagario/client/src/screens/WelcomeScreen.cpp
@@ -65,46 +65,25 @@ void WelcomeScreen::initialize() {
         game_state_.server_ip = text;
     });
 
-    // TCP Port label
-    auto tcp_port_label = std::make_unique<UILabel>(
-        center_x - 90.0f, start_y + 390.0f, "TCP Port:", 18);
-    tcp_port_label->set_color(engine::Color{180, 180, 180, 255});
-    tcp_port_label->set_alignment(UILabel::Alignment::LEFT);
-    labels_.push_back(std::move(tcp_port_label));
+    // Port label (centered)
+    auto port_label = std::make_unique<UILabel>(
+        center_x, start_y + 390.0f, "Port:", 18);
+    port_label->set_color(engine::Color{180, 180, 180, 255});
+    port_label->set_alignment(UILabel::Alignment::CENTER);
+    labels_.push_back(std::move(port_label));
 
-    // TCP Port text field
-    float port_field_width = 90.0f;
+    // Port text field (centered, single field for ENet UDP port)
+    float port_field_width = 100.0f;
     float port_field_height = 40.0f;
-    tcp_port_field_ = std::make_unique<UITextField>(
-        center_x - 90.0f, start_y + 415.0f, port_field_width, port_field_height, "4444");
-    tcp_port_field_->set_text(std::to_string(game_state_.server_tcp_port));
-    tcp_port_field_->set_max_length(5);
-    tcp_port_field_->set_on_change([this](const std::string& text) {
+    port_field_ = std::make_unique<UITextField>(
+        center_x - port_field_width / 2.0f, start_y + 415.0f, port_field_width, port_field_height, "4444");
+    port_field_->set_text(std::to_string(game_state_.server_port));
+    port_field_->set_max_length(5);
+    port_field_->set_on_change([this](const std::string& text) {
         try {
             int port = std::stoi(text);
             if (port > 0 && port <= 65535) {
-                game_state_.server_tcp_port = static_cast<uint16_t>(port);
-            }
-        } catch (...) {}
-    });
-
-    // UDP Port label
-    auto udp_port_label = std::make_unique<UILabel>(
-        center_x + 10.0f, start_y + 390.0f, "UDP Port:", 18);
-    udp_port_label->set_color(engine::Color{180, 180, 180, 255});
-    udp_port_label->set_alignment(UILabel::Alignment::LEFT);
-    labels_.push_back(std::move(udp_port_label));
-
-    // UDP Port text field
-    udp_port_field_ = std::make_unique<UITextField>(
-        center_x + 10.0f, start_y + 415.0f, port_field_width, port_field_height, "4545");
-    udp_port_field_->set_text(std::to_string(game_state_.server_udp_port));
-    udp_port_field_->set_max_length(5);
-    udp_port_field_->set_on_change([this](const std::string& text) {
-        try {
-            int port = std::stoi(text);
-            if (port > 0 && port <= 65535) {
-                game_state_.server_udp_port = static_cast<uint16_t>(port);
+                game_state_.server_port = static_cast<uint16_t>(port);
             }
         } catch (...) {}
     });
@@ -169,14 +148,9 @@ void WelcomeScreen::update(engine::IGraphicsPlugin* graphics, engine::IInputPlug
         ip_field_->update(graphics, input);
     }
 
-    // Update TCP port field
-    if (tcp_port_field_) {
-        tcp_port_field_->update(graphics, input);
-    }
-
-    // Update UDP port field
-    if (udp_port_field_) {
-        udp_port_field_->update(graphics, input);
+    // Update port field
+    if (port_field_) {
+        port_field_->update(graphics, input);
     }
 
     // Update buttons
@@ -225,14 +199,9 @@ void WelcomeScreen::draw(engine::IGraphicsPlugin* graphics) {
         ip_field_->draw(graphics);
     }
 
-    // Draw TCP port field
-    if (tcp_port_field_) {
-        tcp_port_field_->draw(graphics);
-    }
-
-    // Draw UDP port field
-    if (udp_port_field_) {
-        udp_port_field_->draw(graphics);
+    // Draw port field
+    if (port_field_) {
+        port_field_->draw(graphics);
     }
 
     // Draw buttons

--- a/src/bagario/shared/LocalGameState.hpp
+++ b/src/bagario/shared/LocalGameState.hpp
@@ -212,8 +212,7 @@ struct PlayerSkin {
 struct LocalGameState {
     std::string username = "Player";
     std::string server_ip = "127.0.0.1";
-    uint16_t server_tcp_port = 4444;
-    uint16_t server_udp_port = 4545;
+    uint16_t server_port = 4444;  // ENet uses single UDP port
     int music_volume = 70;
     int sfx_volume = 80;
     bool fullscreen = false;
@@ -265,8 +264,7 @@ struct LocalGameState {
 
         username = config.get_string("Profile.username", username);
         server_ip = config.get_string("Network.server_ip", server_ip);
-        server_tcp_port = static_cast<uint16_t>(config.get_int("Network.server_tcp_port", server_tcp_port));
-        server_udp_port = static_cast<uint16_t>(config.get_int("Network.server_udp_port", server_udp_port));
+        server_port = static_cast<uint16_t>(config.get_int("Network.server_port", server_port));
 
         // Load skin settings
         int pattern = config.get_int("Skin.pattern", static_cast<int>(skin.pattern));
@@ -303,8 +301,7 @@ struct LocalGameState {
 
         config.set("Profile.username", username);
         config.set("Network.server_ip", server_ip);
-        config.set("Network.server_tcp_port", static_cast<int>(server_tcp_port));
-        config.set("Network.server_udp_port", static_cast<int>(server_udp_port));
+        config.set("Network.server_port", static_cast<int>(server_port));
 
         config.set("Skin.pattern", static_cast<int>(skin.pattern));
         config.set("Skin.primary_r", static_cast<int>(skin.primary.r));


### PR DESCRIPTION
This pull request refactors the networking configuration for the Bagario client to simplify port management, switching from separate TCP and UDP port fields to a single UDP port field (as required by ENet). The changes update both the user interface and the internal state management to reflect this simplification, improving clarity and reducing potential configuration errors.

**Networking configuration simplification:**

* Replaced separate `server_tcp_port` and `server_udp_port` fields in `LocalGameState` with a single `server_port` field, updating all relevant getters, setters, and defaults. [[1]](diffhunk://#diff-742e838b758bf1425a77036d8dc900f588479b81c6b385a363c29751c517f089L215-R215) [[2]](diffhunk://#diff-742e838b758bf1425a77036d8dc900f588479b81c6b385a363c29751c517f089L268-R267) [[3]](diffhunk://#diff-742e838b758bf1425a77036d8dc900f588479b81c6b385a363c29751c517f089L306-R304)
* Updated the connection logic in `PlayingScreen` to use the unified `server_port` for both parameters in the `network_->connect` call.

**User interface updates:**

* Refactored the welcome screen UI to replace separate TCP and UDP port fields with a single, centered port field, including label and input handling. [[1]](diffhunk://#diff-0ddfcf73cd3553529e83f0b6d6719925f66a39c781f2088ea4a279ced827eb5eL36-R36) [[2]](diffhunk://#diff-eca54a2a514a7d706213124dd325179199ed6f80ecbaf0580b570a3e50380fa3L68-R86)
* Updated field update and draw logic in `WelcomeScreen` to use the new unified port field instead of separate TCP and UDP fields. [[1]](diffhunk://#diff-eca54a2a514a7d706213124dd325179199ed6f80ecbaf0580b570a3e50380fa3L172-R153) [[2]](diffhunk://#diff-eca54a2a514a7d706213124dd325179199ed6f80ecbaf0580b570a3e50380fa3L228-R204)

**Docker configuration update:**

* Changed the exposed port in `Dockerfile.bagario-server` to only expose UDP on port 4444, clarifying ENet's usage of UDP exclusively.