### PR TITLE
feat(game): implement difficulty system affecting gameplay

### DIFF
--- a/src/r-type/server/include/ServerNetworkSystem.hpp
+++ b/src/r-type/server/include/ServerNetworkSystem.hpp
@@ -55,6 +55,13 @@ public:
         player_entities_ = player_entities;
     }
 
+    /**
+     * @brief Set the difficulty level for damage scaling
+     */
+    void set_difficulty(protocol::Difficulty difficulty) {
+        difficulty_ = difficulty;
+    }
+
     void init(Registry& registry) override;
     void update(Registry& registry, float dt) override;
     void shutdown() override;
@@ -214,6 +221,9 @@ private:
 
     // Current scroll position for synchronization with clients (double for precision)
     double current_scroll_x_ = 0.0;
+
+    // Difficulty level for damage scaling
+    protocol::Difficulty difficulty_ = protocol::Difficulty::NORMAL;
 };
 
 }

--- a/src/r-type/server/src/ServerNetworkSystem.cpp
+++ b/src/r-type/server/src/ServerNetworkSystem.cpp
@@ -13,6 +13,7 @@
 #include "ecs/events/InputEvents.hpp"
 #include "components/CombatHelpers.hpp"
 #include "systems/ShootingSystem.hpp"
+#include "GameConfig.hpp"
 
 #include <iostream>
 #include <cmath>
@@ -611,10 +612,14 @@ void ServerNetworkSystem::spawn_enemy_projectile(Registry& registry, Entity owne
 {
     Entity projectile = registry.spawn_entity();
 
+    // Apply difficulty multiplier to enemy projectile damage
+    float damage_mult = rtype::shared::config::get_damage_multiplier(difficulty_);
+    int scaled_damage = static_cast<int>(static_cast<float>(config::ENEMY_PROJECTILE_DAMAGE) * damage_mult);
+
     registry.add_component(projectile, Position{x, y});
     registry.add_component(projectile, Velocity{-config::PROJECTILE_SPEED, 0.0f});
     registry.add_component(projectile, Collider{config::PROJECTILE_WIDTH, config::PROJECTILE_HEIGHT});
-    registry.add_component(projectile, Damage{config::ENEMY_PROJECTILE_DAMAGE});
+    registry.add_component(projectile, Damage{scaled_damage});
     registry.add_component(projectile, Projectile{0.0f, config::PROJECTILE_LIFETIME, 0.0f, ProjectileFaction::Enemy});
     registry.add_component(projectile, ProjectileOwner{owner});  // Track which enemy fired this
     registry.add_component(projectile, NoFriction{});

--- a/src/r-type/shared/GameConfig.hpp
+++ b/src/r-type/shared/GameConfig.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include "protocol/NetworkConfig.hpp"
+#include "protocol/PacketTypes.hpp"
 
 namespace rtype::shared::config {
 
@@ -30,6 +31,27 @@ constexpr float GAME_SCROLL_SPEED = 50.0f;                              // pixel
 constexpr float PLAYER_MOVEMENT_SPEED = 200.0f;                         // pixels per second
 constexpr uint16_t PLAYER_MAX_HEALTH = 1000;
 constexpr uint8_t PLAYER_LIVES = 3;
+
+// === Difficulty Multipliers ===
+// Enemy Health Multipliers (how much more HP enemies have)
+constexpr float DIFFICULTY_EASY_HEALTH_MULT = 0.7f;
+constexpr float DIFFICULTY_NORMAL_HEALTH_MULT = 1.0f;
+constexpr float DIFFICULTY_HARD_HEALTH_MULT = 1.5f;
+
+// Enemy Speed Multipliers (how fast enemies move)
+constexpr float DIFFICULTY_EASY_SPEED_MULT = 0.8f;
+constexpr float DIFFICULTY_NORMAL_SPEED_MULT = 1.0f;
+constexpr float DIFFICULTY_HARD_SPEED_MULT = 1.3f;
+
+// Enemy Damage Multipliers (how much damage enemy projectiles deal)
+constexpr float DIFFICULTY_EASY_DAMAGE_MULT = 0.7f;
+constexpr float DIFFICULTY_NORMAL_DAMAGE_MULT = 1.0f;
+constexpr float DIFFICULTY_HARD_DAMAGE_MULT = 1.5f;
+
+// Player Lives by Difficulty
+constexpr uint8_t DIFFICULTY_EASY_LIVES = 5;
+constexpr uint8_t DIFFICULTY_NORMAL_LIVES = 3;
+constexpr uint8_t DIFFICULTY_HARD_LIVES = 1;
 
 // === Screen / World ===
 constexpr float SCREEN_WIDTH = 1920.0f;
@@ -108,5 +130,55 @@ constexpr float BONUS_SIZE = 12.0f;
 constexpr float EXPLOSION_FRAME_SIZE = 32.0f;
 constexpr float EXPLOSION_FRAME_TIME = 0.04f;
 constexpr float EXPLOSION_DRAW_SCALE = 3.0f;
+
+// === Difficulty Helper Functions ===
+
+/**
+ * @brief Get the health multiplier for a given difficulty
+ */
+inline float get_health_multiplier(protocol::Difficulty difficulty) {
+    switch (difficulty) {
+        case protocol::Difficulty::EASY:   return DIFFICULTY_EASY_HEALTH_MULT;
+        case protocol::Difficulty::NORMAL: return DIFFICULTY_NORMAL_HEALTH_MULT;
+        case protocol::Difficulty::HARD:   return DIFFICULTY_HARD_HEALTH_MULT;
+        default: return DIFFICULTY_NORMAL_HEALTH_MULT;
+    }
+}
+
+/**
+ * @brief Get the speed multiplier for a given difficulty
+ */
+inline float get_speed_multiplier(protocol::Difficulty difficulty) {
+    switch (difficulty) {
+        case protocol::Difficulty::EASY:   return DIFFICULTY_EASY_SPEED_MULT;
+        case protocol::Difficulty::NORMAL: return DIFFICULTY_NORMAL_SPEED_MULT;
+        case protocol::Difficulty::HARD:   return DIFFICULTY_HARD_SPEED_MULT;
+        default: return DIFFICULTY_NORMAL_SPEED_MULT;
+    }
+}
+
+/**
+ * @brief Get the damage multiplier for a given difficulty
+ */
+inline float get_damage_multiplier(protocol::Difficulty difficulty) {
+    switch (difficulty) {
+        case protocol::Difficulty::EASY:   return DIFFICULTY_EASY_DAMAGE_MULT;
+        case protocol::Difficulty::NORMAL: return DIFFICULTY_NORMAL_DAMAGE_MULT;
+        case protocol::Difficulty::HARD:   return DIFFICULTY_HARD_DAMAGE_MULT;
+        default: return DIFFICULTY_NORMAL_DAMAGE_MULT;
+    }
+}
+
+/**
+ * @brief Get the number of player lives for a given difficulty
+ */
+inline uint8_t get_lives_for_difficulty(protocol::Difficulty difficulty) {
+    switch (difficulty) {
+        case protocol::Difficulty::EASY:   return DIFFICULTY_EASY_LIVES;
+        case protocol::Difficulty::NORMAL: return DIFFICULTY_NORMAL_LIVES;
+        case protocol::Difficulty::HARD:   return DIFFICULTY_HARD_LIVES;
+        default: return DIFFICULTY_NORMAL_LIVES;
+    }
+}
 
 } // namespace rtype::shared::config


### PR DESCRIPTION
Add difficulty multipliers that scale enemy stats and player lives:
- Easy: 5 lives, enemies have 70% HP/damage, 80% speed
- Normal: 3 lives, standard enemy stats
- Hard: 1 life, enemies have 150% HP/damage, 130% speed

Enemy health, speed, and projectile damage now scale based on the selected difficulty. Player lives are initialized per difficulty level.