### PR TITLE
feat(level): add 9 waves per level and reduce boss spawn delay

### DIFF
--- a/src/r-type/assets/levels/level_1_mars_assault.json
+++ b/src/r-type/assets/levels/level_1_mars_assault.json
@@ -35,8 +35,8 @@
         {
           "wave_number": 2,
           "trigger": {
-            "chunkId": 2,
-            "offset": 0.0,
+            "chunkId": 0,
+            "offset": 0.5,
             "timeDelay": 0
           },
           "spawns": [
@@ -58,6 +58,80 @@
               "pattern": "single"
             }
           ]
+        },
+        {
+          "wave_number": 3,
+          "trigger": {
+            "chunkId": 1,
+            "offset": 0.0,
+            "timeDelay": 0
+          },
+          "spawns": [
+            {
+              "type": "enemy",
+              "enemyType": "basic",
+              "positionX": 2100,
+              "positionY": 150,
+              "count": 2,
+              "pattern": "line",
+              "spacing": 100
+            },
+            {
+              "type": "enemy",
+              "enemyType": "basic",
+              "positionX": 2100,
+              "positionY": 700,
+              "count": 2,
+              "pattern": "line",
+              "spacing": 100
+            }
+          ]
+        },
+        {
+          "wave_number": 4,
+          "trigger": {
+            "chunkId": 2,
+            "offset": 0.0,
+            "timeDelay": 0
+          },
+          "spawns": [
+            {
+              "type": "enemy",
+              "enemyType": "kamikaze",
+              "positionX": 2200,
+              "positionY": 300,
+              "count": 3,
+              "pattern": "line",
+              "spacing": 180
+            }
+          ]
+        },
+        {
+          "wave_number": 5,
+          "trigger": {
+            "chunkId": 2,
+            "offset": 0.5,
+            "timeDelay": 0
+          },
+          "spawns": [
+            {
+              "type": "enemy",
+              "enemyType": "basic",
+              "positionX": 2100,
+              "positionY": 350,
+              "count": 5,
+              "pattern": "formation",
+              "spacing": 80
+            },
+            {
+              "type": "powerup",
+              "bonusType": "shield",
+              "positionX": 2500,
+              "positionY": 540,
+              "count": 1,
+              "pattern": "single"
+            }
+          ]
         }
       ]
     },
@@ -67,7 +141,137 @@
       "scroll_start": 1440.0,
       "scroll_end": 2880.0,
       "difficulty": "medium",
-      "waves": []
+      "waves": [
+        {
+          "wave_number": 6,
+          "trigger": {
+            "chunkId": 3,
+            "offset": 0.0,
+            "timeDelay": 0
+          },
+          "spawns": [
+            {
+              "type": "enemy",
+              "enemyType": "basic",
+              "positionX": 2100,
+              "positionY": 250,
+              "count": 4,
+              "pattern": "line",
+              "spacing": 120
+            },
+            {
+              "type": "enemy",
+              "enemyType": "kamikaze",
+              "positionX": 2300,
+              "positionY": 600,
+              "count": 2,
+              "pattern": "line",
+              "spacing": 150
+            }
+          ]
+        },
+        {
+          "wave_number": 7,
+          "trigger": {
+            "chunkId": 3,
+            "offset": 0.5,
+            "timeDelay": 0
+          },
+          "spawns": [
+            {
+              "type": "enemy",
+              "enemyType": "basic",
+              "positionX": 2100,
+              "positionY": 200,
+              "count": 1,
+              "pattern": "single",
+              "spacing": 0
+            },
+            {
+              "type": "enemy",
+              "enemyType": "basic",
+              "positionX": 2200,
+              "positionY": 450,
+              "count": 1,
+              "pattern": "single",
+              "spacing": 0
+            },
+            {
+              "type": "enemy",
+              "enemyType": "basic",
+              "positionX": 2100,
+              "positionY": 700,
+              "count": 1,
+              "pattern": "single",
+              "spacing": 0
+            }
+          ]
+        },
+        {
+          "wave_number": 8,
+          "trigger": {
+            "chunkId": 4,
+            "offset": 0.0,
+            "timeDelay": 0
+          },
+          "spawns": [
+            {
+              "type": "enemy",
+              "enemyType": "basic",
+              "positionX": 2100,
+              "positionY": 300,
+              "count": 6,
+              "pattern": "formation",
+              "spacing": 100
+            },
+            {
+              "type": "powerup",
+              "bonusType": "health",
+              "positionX": 2600,
+              "positionY": 540,
+              "count": 1,
+              "pattern": "single"
+            }
+          ]
+        },
+        {
+          "wave_number": 9,
+          "trigger": {
+            "chunkId": 4,
+            "offset": 0.5,
+            "timeDelay": 0
+          },
+          "spawns": [
+            {
+              "type": "enemy",
+              "enemyType": "kamikaze",
+              "positionX": 2100,
+              "positionY": 200,
+              "count": 2,
+              "pattern": "line",
+              "spacing": 150
+            },
+            {
+              "type": "enemy",
+              "enemyType": "kamikaze",
+              "positionX": 2100,
+              "positionY": 650,
+              "count": 2,
+              "pattern": "line",
+              "spacing": 150
+            },
+            {
+              "type": "enemy",
+              "enemyType": "basic",
+              "positionX": 2300,
+              "positionY": 450,
+              "count": 2,
+              "pattern": "line",
+              "spacing": 100
+            }
+          ]
+        }
+      ]
     }
   ],
   "boss": {

--- a/src/r-type/assets/levels/level_3_uranus_station.json
+++ b/src/r-type/assets/levels/level_3_uranus_station.json
@@ -28,13 +28,48 @@
         {
           "wave_number": 2,
           "trigger": {
+            "chunkId": 0,
+            "offset": 0.8,
+            "timeDelay": 0
+          },
+          "spawns": [
+            {"type": "enemy", "enemyType": "kamikaze", "positionX": 2300, "positionY": 250, "count": 3, "pattern": "line", "spacing": 150},
+            {"type": "powerup", "bonusType": "health", "positionX": 2600, "positionY": 450, "count": 1, "pattern": "single"}
+          ]
+        },
+        {
+          "wave_number": 3,
+          "trigger": {
+            "chunkId": 1,
+            "offset": 0.0,
+            "timeDelay": 0
+          },
+          "spawns": [
+            {"type": "enemy", "enemyType": "basic", "positionX": 2100, "positionY": 300, "count": 5, "pattern": "line", "spacing": 120}
+          ]
+        },
+        {
+          "wave_number": 4,
+          "trigger": {
+            "chunkId": 1,
+            "offset": 0.5,
+            "timeDelay": 0
+          },
+          "spawns": [
+            {"type": "enemy", "enemyType": "kamikaze", "positionX": 2100, "positionY": 150, "count": 2, "pattern": "line", "spacing": 100},
+            {"type": "enemy", "enemyType": "kamikaze", "positionX": 2100, "positionY": 750, "count": 1, "pattern": "single", "spacing": 0}
+          ]
+        },
+        {
+          "wave_number": 5,
+          "trigger": {
             "chunkId": 2,
             "offset": 0.0,
             "timeDelay": 0
           },
           "spawns": [
-            {"type": "enemy", "enemyType": "kamikaze", "positionX": 2300, "positionY": 250, "count": 3, "pattern": "line", "spacing": 150},
-            {"type": "powerup", "bonusType": "health", "positionX": 3500, "positionY": 450, "count": 1, "pattern": "single"}
+            {"type": "enemy", "enemyType": "bouncer", "positionX": 2100, "positionY": 350, "count": 4, "pattern": "line", "spacing": 130},
+            {"type": "powerup", "bonusType": "shield", "positionX": 2500, "positionY": 540, "count": 1, "pattern": "single"}
           ]
         }
       ]
@@ -45,7 +80,57 @@
       "scroll_start": 1440.0,
       "scroll_end": 2880.0,
       "difficulty": "hard",
-      "waves": []
+      "waves": [
+        {
+          "wave_number": 6,
+          "trigger": {
+            "chunkId": 2,
+            "offset": 0.5,
+            "timeDelay": 0
+          },
+          "spawns": [
+            {"type": "enemy", "enemyType": "basic", "positionX": 2100, "positionY": 280, "count": 6, "pattern": "formation", "spacing": 90}
+          ]
+        },
+        {
+          "wave_number": 7,
+          "trigger": {
+            "chunkId": 3,
+            "offset": 0.0,
+            "timeDelay": 0
+          },
+          "spawns": [
+            {"type": "enemy", "enemyType": "kamikaze", "positionX": 2100, "positionY": 200, "count": 2, "pattern": "line", "spacing": 120},
+            {"type": "enemy", "enemyType": "kamikaze", "positionX": 2100, "positionY": 650, "count": 2, "pattern": "line", "spacing": 120},
+            {"type": "enemy", "enemyType": "basic", "positionX": 2300, "positionY": 400, "count": 3, "pattern": "line", "spacing": 100}
+          ]
+        },
+        {
+          "wave_number": 8,
+          "trigger": {
+            "chunkId": 3,
+            "offset": 0.5,
+            "timeDelay": 0
+          },
+          "spawns": [
+            {"type": "enemy", "enemyType": "bouncer", "positionX": 2100, "positionY": 300, "count": 5, "pattern": "line", "spacing": 120},
+            {"type": "powerup", "bonusType": "health", "positionX": 2600, "positionY": 540, "count": 1, "pattern": "single"}
+          ]
+        },
+        {
+          "wave_number": 9,
+          "trigger": {
+            "chunkId": 4,
+            "offset": 0.0,
+            "timeDelay": 0
+          },
+          "spawns": [
+            {"type": "enemy", "enemyType": "kamikaze", "positionX": 2100, "positionY": 150, "count": 3, "pattern": "line", "spacing": 100},
+            {"type": "enemy", "enemyType": "kamikaze", "positionX": 2100, "positionY": 700, "count": 3, "pattern": "line", "spacing": 100},
+            {"type": "enemy", "enemyType": "basic", "positionX": 2400, "positionY": 400, "count": 4, "pattern": "line", "spacing": 100}
+          ]
+        }
+      ]
     }
   ],
 

--- a/src/r-type/assets/levels/level_4_jupiter_orbit.json
+++ b/src/r-type/assets/levels/level_4_jupiter_orbit.json
@@ -44,8 +44,8 @@
         {
           "wave_number": 2,
           "trigger": {
-            "chunkId": 2,
-            "offset": 0.0,
+            "chunkId": 0,
+            "offset": 0.85,
             "timeDelay": 0
           },
           "spawns": [
@@ -61,7 +61,81 @@
             {
               "type": "powerup",
               "bonusType": "health",
-              "positionX": 3700,
+              "positionX": 2700,
+              "positionY": 450,
+              "count": 1,
+              "pattern": "single"
+            }
+          ]
+        },
+        {
+          "wave_number": 3,
+          "trigger": {
+            "chunkId": 1,
+            "offset": 0.0,
+            "timeDelay": 0
+          },
+          "spawns": [
+            {
+              "type": "enemy",
+              "enemyType": "kamikaze",
+              "positionX": 2100,
+              "positionY": 300,
+              "count": 4,
+              "pattern": "line",
+              "spacing": 150
+            }
+          ]
+        },
+        {
+          "wave_number": 4,
+          "trigger": {
+            "chunkId": 1,
+            "offset": 0.5,
+            "timeDelay": 0
+          },
+          "spawns": [
+            {
+              "type": "enemy",
+              "enemyType": "bouncer",
+              "positionX": 2100,
+              "positionY": 280,
+              "count": 5,
+              "pattern": "line",
+              "spacing": 130
+            }
+          ]
+        },
+        {
+          "wave_number": 5,
+          "trigger": {
+            "chunkId": 2,
+            "offset": 0.0,
+            "timeDelay": 0
+          },
+          "spawns": [
+            {
+              "type": "enemy",
+              "enemyType": "bouncer",
+              "positionX": 2100,
+              "positionY": 200,
+              "count": 3,
+              "pattern": "line",
+              "spacing": 100
+            },
+            {
+              "type": "enemy",
+              "enemyType": "basic",
+              "positionX": 2100,
+              "positionY": 600,
+              "count": 3,
+              "pattern": "line",
+              "spacing": 100
+            },
+            {
+              "type": "powerup",
+              "bonusType": "shield",
+              "positionX": 2500,
               "positionY": 450,
               "count": 1,
               "pattern": "single"
@@ -76,7 +150,137 @@
       "scroll_start": 1440.0,
       "scroll_end": 2880.0,
       "difficulty": "hard",
-      "waves": []
+      "waves": [
+        {
+          "wave_number": 6,
+          "trigger": {
+            "chunkId": 2,
+            "offset": 0.5,
+            "timeDelay": 0
+          },
+          "spawns": [
+            {
+              "type": "enemy",
+              "enemyType": "bouncer",
+              "positionX": 2100,
+              "positionY": 300,
+              "count": 6,
+              "pattern": "formation",
+              "spacing": 100
+            }
+          ]
+        },
+        {
+          "wave_number": 7,
+          "trigger": {
+            "chunkId": 3,
+            "offset": 0.0,
+            "timeDelay": 0
+          },
+          "spawns": [
+            {
+              "type": "enemy",
+              "enemyType": "kamikaze",
+              "positionX": 2100,
+              "positionY": 200,
+              "count": 2,
+              "pattern": "line",
+              "spacing": 120
+            },
+            {
+              "type": "enemy",
+              "enemyType": "kamikaze",
+              "positionX": 2100,
+              "positionY": 700,
+              "count": 2,
+              "pattern": "line",
+              "spacing": 120
+            },
+            {
+              "type": "enemy",
+              "enemyType": "bouncer",
+              "positionX": 2300,
+              "positionY": 400,
+              "count": 4,
+              "pattern": "line",
+              "spacing": 100
+            }
+          ]
+        },
+        {
+          "wave_number": 8,
+          "trigger": {
+            "chunkId": 3,
+            "offset": 0.5,
+            "timeDelay": 0
+          },
+          "spawns": [
+            {
+              "type": "enemy",
+              "enemyType": "bouncer",
+              "positionX": 2100,
+              "positionY": 180,
+              "count": 3,
+              "pattern": "line",
+              "spacing": 100
+            },
+            {
+              "type": "enemy",
+              "enemyType": "bouncer",
+              "positionX": 2100,
+              "positionY": 650,
+              "count": 2,
+              "pattern": "line",
+              "spacing": 100
+            },
+            {
+              "type": "powerup",
+              "bonusType": "health",
+              "positionX": 2600,
+              "positionY": 450,
+              "count": 1,
+              "pattern": "single"
+            }
+          ]
+        },
+        {
+          "wave_number": 9,
+          "trigger": {
+            "chunkId": 4,
+            "offset": 0.0,
+            "timeDelay": 0
+          },
+          "spawns": [
+            {
+              "type": "enemy",
+              "enemyType": "bouncer",
+              "positionX": 2100,
+              "positionY": 200,
+              "count": 3,
+              "pattern": "line",
+              "spacing": 100
+            },
+            {
+              "type": "enemy",
+              "enemyType": "bouncer",
+              "positionX": 2100,
+              "positionY": 600,
+              "count": 3,
+              "pattern": "line",
+              "spacing": 100
+            },
+            {
+              "type": "enemy",
+              "enemyType": "kamikaze",
+              "positionX": 2400,
+              "positionY": 350,
+              "count": 4,
+              "pattern": "line",
+              "spacing": 120
+            }
+          ]
+        }
+      ]
     }
   ],
   "boss": {

--- a/src/r-type/server/src/WaveManager.cpp
+++ b/src/r-type/server/src/WaveManager.cpp
@@ -52,7 +52,7 @@ void WaveManager::reset()
 
 void WaveManager::check_wave_completion(float delta_time)
 {
-    const float WAVE_COMPLETION_TIMEOUT = 30.0f;
+    const float WAVE_COMPLETION_TIMEOUT = 8.0f;
 
     for (auto& wave : config_.waves) {
         if (wave.triggered && !wave.completed) {


### PR DESCRIPTION
- Expand levels 1, 3, and 4 from 2 waves to 9 waves each
- Reduce WAVE_COMPLETION_TIMEOUT from 30s to 8s for faster boss spawn
- Add variety with basic, kamikaze, and bouncer enemies
- Include powerups (health, shield) throughout waves