### PR TITLE
feat(levels): add missing enemy types to level configurations

### DIFF
--- a/src/r-type/assets/levels/level_1_mars_assault.json
+++ b/src/r-type/assets/levels/level_1_mars_assault.json
@@ -69,7 +69,7 @@
           "spawns": [
             {
               "type": "enemy",
-              "enemyType": "basic",
+              "enemyType": "fast",
               "positionX": 2100,
               "positionY": 150,
               "count": 2,
@@ -78,7 +78,7 @@
             },
             {
               "type": "enemy",
-              "enemyType": "basic",
+              "enemyType": "fast",
               "positionX": 2100,
               "positionY": 700,
               "count": 2,
@@ -180,17 +180,8 @@
           "spawns": [
             {
               "type": "enemy",
-              "enemyType": "basic",
+              "enemyType": "tank",
               "positionX": 2100,
-              "positionY": 200,
-              "count": 1,
-              "pattern": "single",
-              "spacing": 0
-            },
-            {
-              "type": "enemy",
-              "enemyType": "basic",
-              "positionX": 2200,
               "positionY": 450,
               "count": 1,
               "pattern": "single",
@@ -198,12 +189,21 @@
             },
             {
               "type": "enemy",
-              "enemyType": "basic",
-              "positionX": 2100,
+              "enemyType": "bouncer",
+              "positionX": 2300,
+              "positionY": 200,
+              "count": 2,
+              "pattern": "line",
+              "spacing": 120
+            },
+            {
+              "type": "enemy",
+              "enemyType": "bouncer",
+              "positionX": 2300,
               "positionY": 700,
-              "count": 1,
-              "pattern": "single",
-              "spacing": 0
+              "count": 2,
+              "pattern": "line",
+              "spacing": 120
             }
           ]
         },

--- a/src/r-type/assets/levels/level_3_uranus_station.json
+++ b/src/r-type/assets/levels/level_3_uranus_station.json
@@ -45,7 +45,8 @@
             "timeDelay": 0
           },
           "spawns": [
-            {"type": "enemy", "enemyType": "basic", "positionX": 2100, "positionY": 300, "count": 5, "pattern": "line", "spacing": 120}
+            {"type": "enemy", "enemyType": "fast", "positionX": 2100, "positionY": 300, "count": 3, "pattern": "line", "spacing": 120},
+            {"type": "enemy", "enemyType": "basic", "positionX": 2100, "positionY": 600, "count": 2, "pattern": "line", "spacing": 100}
           ]
         },
         {
@@ -89,7 +90,9 @@
             "timeDelay": 0
           },
           "spawns": [
-            {"type": "enemy", "enemyType": "basic", "positionX": 2100, "positionY": 280, "count": 6, "pattern": "formation", "spacing": 90}
+            {"type": "enemy", "enemyType": "tank", "positionX": 2100, "positionY": 450, "count": 1, "pattern": "single", "spacing": 0},
+            {"type": "enemy", "enemyType": "basic", "positionX": 2300, "positionY": 200, "count": 3, "pattern": "line", "spacing": 90},
+            {"type": "enemy", "enemyType": "basic", "positionX": 2300, "positionY": 700, "count": 3, "pattern": "line", "spacing": 90}
           ]
         },
         {

--- a/src/r-type/assets/levels/level_4_jupiter_orbit.json
+++ b/src/r-type/assets/levels/level_4_jupiter_orbit.json
@@ -78,10 +78,19 @@
           "spawns": [
             {
               "type": "enemy",
+              "enemyType": "fast",
+              "positionX": 2100,
+              "positionY": 250,
+              "count": 3,
+              "pattern": "line",
+              "spacing": 120
+            },
+            {
+              "type": "enemy",
               "enemyType": "kamikaze",
               "positionX": 2100,
-              "positionY": 300,
-              "count": 4,
+              "positionY": 600,
+              "count": 2,
               "pattern": "line",
               "spacing": 150
             }
@@ -161,11 +170,29 @@
           "spawns": [
             {
               "type": "enemy",
-              "enemyType": "bouncer",
+              "enemyType": "tank",
               "positionX": 2100,
-              "positionY": 300,
-              "count": 6,
-              "pattern": "formation",
+              "positionY": 450,
+              "count": 1,
+              "pattern": "single",
+              "spacing": 0
+            },
+            {
+              "type": "enemy",
+              "enemyType": "bouncer",
+              "positionX": 2300,
+              "positionY": 200,
+              "count": 3,
+              "pattern": "line",
+              "spacing": 100
+            },
+            {
+              "type": "enemy",
+              "enemyType": "bouncer",
+              "positionX": 2300,
+              "positionY": 700,
+              "count": 3,
+              "pattern": "line",
               "spacing": 100
             }
           ]


### PR DESCRIPTION
Add fast, tank and bouncer enemies to levels 1, 3 and 4 for more variety. Level 2 (Nebula) kept unchanged as requested.
- Level 1: add fast, tank, bouncer
- Level 3: add fast, tank
- Level 4: add fast, tank