### PR TITLE
Test ci

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -84,14 +84,15 @@ jobs:
       # ==========================================
       # BUILD & PUSH R-TYPE SERVER
       # ==========================================
-      - name: Build and push R-Type Server
+      - name: Build R-Type Server image
         uses: docker/build-push-action@v5
         timeout-minutes: 20
         with:
           context: .
           file: ./Dockerfile.rtype-server
           platforms: linux/arm64
-          push: true
+          push: false
+          load: true
           tags: ${{ steps.meta.outputs.rtype_tags }}
           labels: |
             org.opencontainers.image.source=${{ github.repositoryUrl }}
@@ -101,21 +102,48 @@ jobs:
           cache-to: type=gha,mode=max,scope=rtype-server
           provenance: false
           sbom: false
-          build-args: |
-            BUILDKIT_INLINE_CACHE=1
-          outputs: type=image,push=true,compression=gzip,compression-level=6
+          outputs: type=docker
+
+      - name: Push R-Type Server image with retry
+        timeout-minutes: 15
+        run: |
+          TAGS="${{ steps.meta.outputs.rtype_tags }}"
+          IFS=',' read -ra TAG_ARRAY <<< "$TAGS"
+
+          for tag in "${TAG_ARRAY[@]}"; do
+            echo "Pushing $tag..."
+            retry_count=0
+            max_retries=3
+
+            while [ $retry_count -lt $max_retries ]; do
+              if docker push "$tag"; then
+                echo "Successfully pushed $tag"
+                break
+              else
+                retry_count=$((retry_count + 1))
+                if [ $retry_count -lt $max_retries ]; then
+                  echo "Push failed, retrying ($retry_count/$max_retries)..."
+                  sleep 10
+                else
+                  echo "Failed to push $tag after $max_retries attempts"
+                  exit 1
+                fi
+              fi
+            done
+          done
 
       # ==========================================
       # BUILD & PUSH BAGARIO SERVER
       # ==========================================
-      - name: Build and push Bagario Server
+      - name: Build Bagario Server image
         uses: docker/build-push-action@v5
         timeout-minutes: 20
         with:
           context: .
           file: ./Dockerfile.bagario-server
           platforms: linux/arm64
-          push: true
+          push: false
+          load: true
           tags: ${{ steps.meta.outputs.bagario_tags }}
           labels: |
             org.opencontainers.image.source=${{ github.repositoryUrl }}
@@ -125,9 +153,35 @@ jobs:
           cache-to: type=gha,mode=max,scope=bagario-server
           provenance: false
           sbom: false
-          build-args: |
-            BUILDKIT_INLINE_CACHE=1
-          outputs: type=image,push=true,compression=gzip,compression-level=6
+          outputs: type=docker
+
+      - name: Push Bagario Server image with retry
+        timeout-minutes: 15
+        run: |
+          TAGS="${{ steps.meta.outputs.bagario_tags }}"
+          IFS=',' read -ra TAG_ARRAY <<< "$TAGS"
+
+          for tag in "${TAG_ARRAY[@]}"; do
+            echo "Pushing $tag..."
+            retry_count=0
+            max_retries=3
+
+            while [ $retry_count -lt $max_retries ]; do
+              if docker push "$tag"; then
+                echo "Successfully pushed $tag"
+                break
+              else
+                retry_count=$((retry_count + 1))
+                if [ $retry_count -lt $max_retries ]; then
+                  echo "Push failed, retrying ($retry_count/$max_retries)..."
+                  sleep 10
+                else
+                  echo "Failed to push $tag after $max_retries attempts"
+                  exit 1
+                fi
+              fi
+            done
+          done
 
       # ==========================================
       # SECURITY SCANS


### PR DESCRIPTION
This pull request updates the deployment workflow in `.github/workflows/deploy.yaml` to improve Docker build reliability, security, and performance. The changes enhance certificate handling for BuildKit, add resource controls, improve build caching, and optimize image output.

**Docker/BuildKit configuration and security improvements:**

* Added CA certificate setup for BuildKit in addition to Docker, ensuring both recognize the registry's certificate. The Docker service is now restarted to apply certificate changes. ([[.github/workflows/deploy.yamlR43-R64](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R43-R64)])
* Updated the Buildx setup to use host networking, enable debug flags, and explicitly set registry security options (`http = false`, `insecure = false`). ([[.github/workflows/deploy.yamlR43-R64](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R43-R64)])

**Performance and reliability enhancements:**

* Limited parallelism for both OCI and containerd BuildKit workers to 2, which can help control resource usage and avoid overloading the build environment. ([[.github/workflows/deploy.yamlR43-R64](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R43-R64)])
* Added a 20-minute timeout to both the R-Type Server and Bagario Server build steps to prevent jobs from hanging indefinitely. ([[.github/workflows/deploy.yamlR89](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R89)])

**Build and image output optimizations:**

* Enabled inline build cache with the `BUILDKIT_INLINE_CACHE=1` build argument for both server builds, improving cache reuse in subsequent builds. [[1]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R104-R113)], [[2]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R128-R130)])
* Set image outputs to use gzip compression at level 6 for pushed images, optimizing image size and transfer speed. [[1]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R104-R113)], [[2]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R128-R130)])