### PR TITLE
fix: not pure abtract class

### DIFF
--- a/tests/ecs/test_render_system.cpp
+++ b/tests/ecs/test_render_system.cpp
@@ -93,6 +93,9 @@ public:
     void begin_blend_mode(int) override {}
     void end_blend_mode() override {}
 
+    // Accessibility (not used in tests)
+    void set_colorblind_mode(engine::ColorBlindMode) override {}
+
     // Test helpers
     int get_draw_call_count() const { return draw_sprite_call_count_; }
     const std::vector<engine::Vector2f>& get_drawn_positions() const {


### PR DESCRIPTION
This pull request adds a small change to the `MockGraphicsPlugin` class in the test suite. The update introduces a stub implementation for the `set_colorblind_mode` method, ensuring the mock class fully implements the `IGraphicsPlugin` interface. This improves interface compliance for future accessibility features.

* Added a stub for `set_colorblind_mode` to `MockGraphicsPlugin` for interface completeness.