### PR TITLE
feat: add dispatch mode for CI PRD

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,6 +1,7 @@
 name: Build and Deploy R-Type & Bagario Servers
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
This pull request introduces a small update to the GitHub Actions workflow configuration. The change enables manual triggering of the workflow through the GitHub Actions interface by adding the `workflow_dispatch` event to `.github/workflows/deploy.yaml`.