### PR TITLE
Small fix due to debug values not removed

### DIFF
--- a/src/engine/src/plugins/input/raylib/RaylibInputPlugin.cpp
+++ b/src/engine/src/plugins/input/raylib/RaylibInputPlugin.cpp
@@ -86,6 +86,13 @@ void RaylibInputPlugin::init_key_mapping() {
     key_mapping[engine::Key::LAlt] = KEY_LEFT_ALT;
     key_mapping[engine::Key::RAlt] = KEY_RIGHT_ALT;
 
+    // Special characters
+    key_mapping[engine::Key::Period] = KEY_PERIOD;
+    key_mapping[engine::Key::Comma] = KEY_COMMA;
+    key_mapping[engine::Key::Slash] = KEY_SLASH;
+    key_mapping[engine::Key::Hyphen] = KEY_MINUS;
+    key_mapping[engine::Key::Semicolon] = KEY_SEMICOLON;
+
     // Function keys
     key_mapping[engine::Key::F1] = KEY_F1;
     key_mapping[engine::Key::F2] = KEY_F2;

--- a/src/r-type/game-logic/src/systems/HealthSystem.cpp
+++ b/src/r-type/game-logic/src/systems/HealthSystem.cpp
@@ -53,7 +53,7 @@ void HealthSystem::init(Registry& registry)
                     if (projectileOwners.has_entity(event.source)) {
                         killer = projectileOwners[event.source].owner;
                     }
-                    registry.get_event_bus().publish(ecs::EnemyKilledEvent{event.target, 10000, killer});
+                    registry.get_event_bus().publish(ecs::EnemyKilledEvent{event.target, 100, killer});
                     auto& positions = registry.get_components<Position>();
                     auto& ais = registry.get_components<AI>();
                     if (positions.has_entity(event.target)) {

--- a/src/r-type/game-logic/src/systems/ShootingSystem.cpp
+++ b/src/r-type/game-logic/src/systems/ShootingSystem.cpp
@@ -374,7 +374,7 @@ void ShootingSystem::updateLaserBeam(Registry& registry, Entity shooter, const P
                         if (healths[enemy].current <= 0) {
                             registry.add_component(enemy, ToDestroy{});
                             // Publier l'événement pour le score (100 points par défaut)
-                            registry.get_event_bus().publish(ecs::EnemyKilledEvent{enemy, 10000, shooter});
+                            registry.get_event_bus().publish(ecs::EnemyKilledEvent{enemy, 100, shooter});
                         }
                     }
                     // Arrêter au premier ennemi touché


### PR DESCRIPTION
This pull request introduces a few targeted changes to improve input handling and scoring logic in the game. The most significant updates are the addition of special character key mappings in the Raylib input plugin and the adjustment of enemy kill score values from 10,000 to 100 points in the health and shooting systems.

**Input handling improvements:**
* Added support for special character keys (`Period`, `Comma`, `Slash`, `Hyphen`, and `Semicolon`) to the `RaylibInputPlugin` key mapping, enabling correct detection of these keys in-game.

**Game logic and scoring adjustments:**
* Changed the score awarded for killing an enemy from 10,000 to 100 points in both the `HealthSystem` and `ShootingSystem`, standardizing and balancing the scoring system. [[1]](diffhunk://#diff-4bef40951acf05da2613345e26e941e1c31698389418fd962a36982a654993aeL56-R56) [[2]](diffhunk://#diff-7e4dd220ebb5acb8f58b326e8316a15f06d19838831f5346dabf7895c340f397L377-R377)